### PR TITLE
chore: add debug config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,16 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
-			"name": "ide-extension",
+			"name": "npm run dev",
+			"type": "node",
+			"request": "launch",
+			"cwd": "${workspaceFolder}",
+			"runtimeExecutable": "npm",
+			"runtimeArgs": ["run-script", "dev"],
+			"console": "integratedTerminal"
+		},
+		{
+			"name": "debug ide-extension",
 			"type": "extensionHost",
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
@@ -15,17 +24,38 @@
 			],
 			"outFiles": ["${workspaceFolder}/source-code/ide-extension/dist/**/*.js"]
 		},
+		// {
+		// 	"name": "Current test file",
+		// 	"type": "node",
+		// 	"request": "launch",
+		// 	"autoAttachChildProcesses": true,
+		// 	"skipFiles": ["<node_internals>/**", "**/node_modules/**"],
+		// 	"program": "${workspaceRoot}/node_modules/vitest/vitest.mjs",
+		// 	"args": ["run", "${relativeFile}"],
+		// 	"smartStep": true,
+		// 	"console": "integratedTerminal"
+		// },
 		{
-			"type": "node",
+			"name": "open @inlang/website in chrome",
+			"port": 3000,
 			"request": "launch",
-			"name": "Current test file",
-			"autoAttachChildProcesses": true,
-			"skipFiles": ["<node_internals>/**", "**/node_modules/**"],
-			"program": "${workspaceRoot}/node_modules/vitest/vitest.mjs",
-			"args": ["run", "${relativeFile}"],
-			"smartStep": true,
-			"console": "integratedTerminal",
-			"runtimeExecutable": "/opt/homebrew/bin/node"
+			"type": "chrome",
+			"webRoot": "${workspaceFolder}/source-code/website",
+			// annoying bug. the website does not load if the server is not started beforehand. 
+			"file": "${workspaceFolder}/.vscode/wait-for-process.html"
+		}
+	],
+	"compounds": [
+		{
+			// start the entire dev environment
+			"name": "start development environement",
+			"configurations": ["npm run dev", "open @inlang/website in chrome"],
+			"stopAll": true,
+			"presentation": {
+				"hidden": false,
+				"group": "",
+				"order": 1
+			}
 		}
 	]
 }

--- a/.vscode/wait-for-process.html
+++ b/.vscode/wait-for-process.html
@@ -1,0 +1,18 @@
+<h2>proceed to <a href="http://localhost:3000">localhost:3000</a></h2>
+
+<h3 style="color: darkred">NOTE: wait for 5-10 seconds</h3>
+<p style="color: darkred">
+	the server on port 3000 must be running as indicated in the terminal with
+	<code>Server running at localhost:3000</code> in the terminal.
+</p>
+
+<br />
+<hr />
+<br />
+
+<h4>Why is this displayed?</h4>
+<p>
+	For whatever reason, chrome does not load localhost:3000 if the server is not
+	running. EVEN after the server has been started. A simple refresh does not
+	work.
+</p>


### PR DESCRIPTION
Pressing `F5` now provides a debuggable development environment. 

With one tiny exception: Files that are being processed by vite-plugin-ssr have a sourcemap mismatch. I will, most likely, open a discussion in vite-plugin-ssr's repository. 