### PR TITLE
refactor: out-comment placeholder type

### DIFF
--- a/source-code/core/src/ast/index.ts
+++ b/source-code/core/src/ast/index.ts
@@ -10,6 +10,10 @@ export type Node<Name> = {
 	metadata?: unknown;
 };
 
+export type Identifier = Node<"Identifier"> & {
+	name: string;
+};
+
 export type Bundle = Node<"Bundle"> & {
 	id: Identifier;
 	resources: Resource[];
@@ -31,46 +35,42 @@ export type Message = Node<"Message"> & {
 };
 
 export type Pattern = Node<"Pattern"> & {
-	elements: Array<Text | Placeholder>;
+	elements: Array<Text>;
 };
 
 export type Text = Node<"Text"> & {
 	value: string;
 };
 
-export type Placeholder = Node<"Placeholder"> & {
-	expression: Expression;
-};
+// export type Placeholder = Node<"Placeholder"> & {
+// 	expression: Expression;
+// };
 
-/**
- * A subset of expressions which can be used as outside of Placeholders.
- */
-export type InlineExpression = Literal | Function | Variable | Placeholder;
-export declare type Expression = InlineExpression | SelectExpression;
+// /**
+//  * A subset of expressions which can be used as outside of Placeholders.
+//  */
+// export type InlineExpression = Literal | Function | Variable | Placeholder;
+// export declare type Expression = InlineExpression | SelectExpression;
 
-export type Literal = Node<"Literal"> & {
-	value: string;
-};
+// export type Literal = Node<"Literal"> & {
+// 	value: string;
+// };
 
-export type Variable = Node<"Variable"> & {
-	id: Identifier;
-};
+// export type Variable = Node<"Variable"> & {
+// 	id: Identifier;
+// };
 
-export type Function = Node<"Function"> & {
-	id: Identifier;
-};
+// export type Function = Node<"Function"> & {
+// 	id: Identifier;
+// };
 
-export type SelectExpression = Node<"SelectExpression"> & {
-	selector: InlineExpression;
-	variants: Array<Variant>;
-};
+// export type SelectExpression = Node<"SelectExpression"> & {
+// 	selector: InlineExpression;
+// 	variants: Array<Variant>;
+// };
 
-export type Variant = Node<"Variant"> & {
-	id: Identifier;
-	pattern: Pattern;
-	default: boolean;
-};
-
-export type Identifier = Node<"Identifier"> & {
-	name: string;
-};
+// export type Variant = Node<"Variant"> & {
+// 	id: Identifier;
+// 	pattern: Pattern;
+// 	default: boolean;
+// };

--- a/source-code/website/src/pages/editor/@host/@organization/@repository/Messages.tsx
+++ b/source-code/website/src/pages/editor/@host/@organization/@repository/Messages.tsx
@@ -213,55 +213,55 @@ function PatternEditor(props: {
 }
 
 /** will probably be replaced with #164 */
-function PatternElement(props: { element: ast.Text | ast.Placeholder }) {
-	/** Switch fallback error (non-exhaustive switch statement) */
-	const Error = (props: { code: string }) => (
-		<span class="text-danger">
-			You encountered a bug. please file the bug and mention code {props.code}
-		</span>
-	);
+// function PatternElement(props: { element: ast.Text | ast.Placeholder }) {
+// 	/** Switch fallback error (non-exhaustive switch statement) */
+// 	const Error = (props: { code: string }) => (
+// 		<span class="text-danger">
+// 			You encountered a bug. please file the bug and mention code {props.code}
+// 		</span>
+// 	);
 
-	/** visually differentiate between text and placeholder elements */
-	const Placeholder = (props: { children: JSXElement }) => (
-		<code class="bg-tertiary-container rounded text-on-tertiary-container font-medium">
-			{props.children}
-		</code>
-	);
+// 	/** visually differentiate between text and placeholder elements */
+// 	const Placeholder = (props: { children: JSXElement }) => (
+// 		<code class="bg-tertiary-container rounded text-on-tertiary-container font-medium">
+// 			{props.children}
+// 		</code>
+// 	);
 
-	return (
-		<Switch fallback={<Error code="2903ns"></Error>}>
-			<Match when={props.element.type === "Text"}>
-				<span>{(props.element as ast.Text).value}</span>
-			</Match>
-			<Match when={props.element.type === "Placeholder"}>
-				<Switch fallback={<Error code="2203sfss"></Error>}>
-					{(() => {
-						// defining a variable to avoid type assertions and lengthier code
-						const expression = (props.element as ast.Placeholder).expression;
-						return (
-							<>
-								<Match when={expression.type === "Literal"}>
-									<Placeholder>{(expression as ast.Literal).value}</Placeholder>
-								</Match>
-								<Match when={expression.type === "Function"}>
-									<Placeholder>
-										{(expression as ast.Function).id.name}
-									</Placeholder>
-								</Match>
-								<Match when={expression.type === "Variable"}>
-									<Placeholder>
-										{(expression as ast.Variable).id.name}
-									</Placeholder>
-								</Match>
-								<Match when={expression.type === "Placeholder"}>
-									{/* recursively call pattern element */}
-									<PatternElement element={props.element}></PatternElement>
-								</Match>
-							</>
-						);
-					})()}
-				</Switch>
-			</Match>
-		</Switch>
-	);
-}
+// 	return (
+// 		<Switch fallback={<Error code="2903ns"></Error>}>
+// 			<Match when={props.element.type === "Text"}>
+// 				<span>{(props.element as ast.Text).value}</span>
+// 			</Match>
+// 			<Match when={props.element.type === "Placeholder"}>
+// 				<Switch fallback={<Error code="2203sfss"></Error>}>
+// 					{(() => {
+// 						// defining a variable to avoid type assertions and lengthier code
+// 						const expression = (props.element as ast.Placeholder).expression;
+// 						return (
+// 							<>
+// 								<Match when={expression.type === "Literal"}>
+// 									<Placeholder>{(expression as ast.Literal).value}</Placeholder>
+// 								</Match>
+// 								<Match when={expression.type === "Function"}>
+// 									<Placeholder>
+// 										{(expression as ast.Function).id.name}
+// 									</Placeholder>
+// 								</Match>
+// 								<Match when={expression.type === "Variable"}>
+// 									<Placeholder>
+// 										{(expression as ast.Variable).id.name}
+// 									</Placeholder>
+// 								</Match>
+// 								<Match when={expression.type === "Placeholder"}>
+// 									{/* recursively call pattern element */}
+// 									<PatternElement element={props.element}></PatternElement>
+// 								</Match>
+// 							</>
+// 						);
+// 					})()}
+// 				</Switch>
+// 			</Match>
+// 		</Switch>
+// 	);
+// }


### PR DESCRIPTION
closes simplify AST by removing (currently) unsupported Placeholder types ahead of launch #204

<a href="https://gitpod.io/#https://github.com/inlang/inlang/pull/205"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

