### PR TITLE
fix: rename surface colors and use alpha

### DIFF
--- a/source-code/design-system/src/color-system/generateTokens.cts
+++ b/source-code/design-system/src/color-system/generateTokens.cts
@@ -4,8 +4,6 @@ import { TinyColor } from "@ctrl/tinycolor";
 import type { Color } from "./types/color.cjs";
 
 // todos:
-// - support surface levels (100,200,300,400,500)
-//   see https://m3.material.io/styles/color/the-color-system/color-roles
 // - support for custom colors
 // - non-hardcoded version
 // - derive dark/light mode colors
@@ -23,20 +21,22 @@ export function generateTokens(config: Config): ColorTokens {
 		"on-background": neutralColors.neutral[900],
 		// the surface color spec is derived from
 		// https://m3.material.io/styles/color/the-color-system/color-roles#c0cdc1ba-7e67-4d6a-b294-218f659ff648
-		"surface-100": new TinyColor(neutralColors.neutral[900])
-			.lighten(88)
+		// using neutral colors though to not be too colorful (while we don't have a designer on the team that
+		// ensures that colors are matching the overall design)
+		"surface-1": new TinyColor(neutralColors.neutral[900])
+			.setAlpha(0.05)
 			.toHex8String(),
-		"surface-200": new TinyColor(neutralColors.neutral[900])
-			.lighten(85)
+		"surface-2": new TinyColor(neutralColors.neutral[900])
+			.setAlpha(0.08)
 			.toHex8String(),
-		"surface-300": new TinyColor(neutralColors.neutral[900])
-			.lighten(82)
+		"surface-3": new TinyColor(neutralColors.neutral[900])
+			.setAlpha(0.11)
 			.toHex8String(),
-		"surface-400": new TinyColor(neutralColors.neutral[900])
-			.lighten(81)
+		"surface-4": new TinyColor(neutralColors.neutral[900])
+			.setAlpha(0.12)
 			.toHex8String(),
-		"surface-500": new TinyColor(neutralColors.neutral[900])
-			.lighten(79)
+		"surface-5": new TinyColor(neutralColors.neutral[900])
+			.setAlpha(0.14)
 			.toHex8String(),
 		"on-surface": neutralColors.neutral[900],
 		"surface-variant": neutralColors.neutralVariant[100],
@@ -80,14 +80,11 @@ export function generateTokens(config: Config): ColorTokens {
 	//
 	// disabled states always use the on-surface color but with
 	// different opacity values
-	// colors[`disabled-content`] = new TinyColor(colors["on-surface-100-container"])
-	//   .setAlpha(38)
-	//   .toHex8String();
 	tokens[`disabled-content`] = new TinyColor(tokens["on-surface"])
-		.lighten(60)
+		.setAlpha(38)
 		.toHex8String();
 	tokens[`disabled-container`] = new TinyColor(tokens["on-surface"])
-		.lighten(75)
+		.setAlpha(12)
 		.toHex8String();
 
 	return tokens as ColorTokens;

--- a/source-code/design-system/src/color-system/types/colorTokens.cts
+++ b/source-code/design-system/src/color-system/types/colorTokens.cts
@@ -20,14 +20,14 @@ export type ColorTokens = {
 	background: string;
 	"on-background": string;
 
-	"surface-100": string;
-	"surface-200": string;
-	"surface-300": string;
-	"surface-400": string;
-	"surface-500": string;
+	"surface-1": string;
+	"surface-2": string;
+	"surface-3": string;
+	"surface-4": string;
+	"surface-5": string;
 
 	// utility on-surface color. avoids the need to reference
-	// on-surface-100, on-surface-200, etc.
+	// on-surface-1, on-surface-2, etc.
 	"on-surface": string;
 
 	"surface-variant": string;

--- a/source-code/website/src/components/_old/Menu.tsx
+++ b/source-code/website/src/components/_old/Menu.tsx
@@ -68,12 +68,7 @@ export function MenuTrigger(props: { children?: JSXElement }) {
  * @param props.color surface color as defined in https://m3.material.io/components/menus/specs#ad796ca6-3d66-4e7e-9322-c0d93bff5423
  */
 export function MenuContent(props: {
-	color:
-		| "surface-100"
-		| "surface-200"
-		| "surface-300"
-		| "surface-400"
-		| "surface-500";
+	color: "surface-1" | "surface-2" | "surface-3" | "surface-4" | "surface-5";
 	children?: JSXElement;
 }) {
 	const api = useMenu();

--- a/source-code/website/src/pages/Layout.tsx
+++ b/source-code/website/src/pages/Layout.tsx
@@ -60,7 +60,7 @@ function Header() {
 	const [mobileMenuIsOpen, setMobileMenuIsOpen] = createSignal(false);
 
 	return (
-		<header class="sticky top-0 z-50 w-full bg-surface-100 border-b border-outline-variant py-3">
+		<header class="sticky top-0 z-50 w-full bg-surface-1 border-b border-outline-variant py-3">
 			<nav class={layoutMargins}>
 				<div class="flex gap-8">
 					<a href="/" class="flex items-center">
@@ -140,7 +140,7 @@ function Header() {
 
 function Footer() {
 	return (
-		<footer class="sticky z-40 w-full border-t border-outline-variant bg-surface-100 py-1">
+		<footer class="sticky z-40 w-full border-t border-outline-variant bg-surface-1 py-1">
 			<div class={`flex gap-8  ${layoutMargins}`}>
 				{/* <a href="/legal.txt" class="link  link-primary font-light">
 					<span class="">legal.txt</span>
@@ -203,7 +203,7 @@ function UserDropdown() {
 							<IconExpand></IconExpand>
 						</div>
 						<sl-menu>
-							<div class="px-7 py-2 bg-surface-100 text-on-surface">
+							<div class="px-7 py-2 bg-surface-1 text-on-surface">
 								<p>Signed in as</p>
 								<p class="font-medium">{localStorage.user?.username}</p>
 							</div>


### PR DESCRIPTION
Material uses opacity for the surface colors which seemed like an odd choice because elements are transparent. The choice of using opacity is awesome though. Using opacity allows the layering of surface colors.

To illustrate the difference of surface color tokens to tailwind colors, the surface colors have also been renamed to the original material token e.g. `surface-100` is now `surface-1`. The latter should be read as "surface level 1". Surface colors should never be used with tailwinds opacity modifier e.g. `surface-100/10`.