### PR TITLE
fix: redundant clone repository calls

### DIFF
--- a/source-code/core/src/config/index.ts
+++ b/source-code/core/src/config/index.ts
@@ -1,2 +1,2 @@
-export type { Config } from "./schema.js";
+export * from "./schema.js";
 export * from "./environment-functions/index.js";

--- a/source-code/website/src/pages/Layout.tsx
+++ b/source-code/website/src/pages/Layout.tsx
@@ -103,7 +103,7 @@ function Header() {
 							<div class="hidden md:flex justify-end space-x-4 place-items-center">
 								<Show
 									when={
-										currentPageContext().urlParsed.pathname.includes(
+										currentPageContext.urlParsed.pathname.includes(
 											"editor"
 										) === false
 									}
@@ -118,7 +118,7 @@ function Header() {
 								<Show
 									when={
 										localStorage.user ||
-										currentPageContext().urlParsed.pathname.includes("editor")
+										currentPageContext.urlParsed.pathname.includes("editor")
 									}
 								>
 									<UserDropdown></UserDropdown>

--- a/source-code/website/src/pages/documentation/*/index.page.tsx
+++ b/source-code/website/src/pages/documentation/*/index.page.tsx
@@ -64,7 +64,7 @@ export function Page(props: PageProps) {
 					*/}
 					<div class="w-full prose justify-self-center md:pt-6 md:col-span-3">
 						<Show
-							when={currentPageContext().urlParsed.pathname.includes("rfc")}
+							when={currentPageContext.urlParsed.pathname.includes("rfc")}
 						>
 							<Callout variant="warning">
 								<p>
@@ -114,10 +114,10 @@ function NavbarCommon(props: {
 											classList={{
 												"text-primary":
 													document.frontmatter.href ===
-													currentPageContext().urlParsed.pathname,
+													currentPageContext.urlParsed.pathname,
 												"text-on-surface-variant":
 													document.frontmatter.href !==
-													currentPageContext().urlParsed.pathname,
+													currentPageContext.urlParsed.pathname,
 											}}
 											href={document.frontmatter.href}
 										>

--- a/source-code/website/src/pages/editor/@host/@organization/@repository/index.page.tsx
+++ b/source-code/website/src/pages/editor/@host/@organization/@repository/index.page.tsx
@@ -8,17 +8,16 @@ import {
 	inlangConfig,
 	referenceBundle,
 	repositoryIsCloned,
-	routeParams,
 } from "@src/pages/editor/state.js";
 import { Layout as EditorLayout } from "@src/pages/editor/Layout.jsx";
 import type * as ast from "@inlang/core/ast";
+import type { EditorRouteParams } from "@src/pages/editor/types.js";
 
-export const Head: PageHead = () => {
+export const Head: PageHead = (props) => {
+	const routeParams = props.pageContext.routeParams as EditorRouteParams;
 	return {
-		title: routeParams().organization + "/" + routeParams().repository,
-		description: `Contribute translations to ${
-			routeParams().repository
-		} via inlangs editor.`,
+		title: routeParams.organization + "/" + routeParams.repository,
+		description: `Contribute translations to ${routeParams.repository} via inlangs editor.`,
 	};
 };
 

--- a/source-code/website/src/pages/editor/Layout.tsx
+++ b/source-code/website/src/pages/editor/Layout.tsx
@@ -20,6 +20,7 @@ import { currentPageContext } from "@src/renderer/state.js";
 import { showToast } from "@src/components/Toast.jsx";
 import { Layout as RootLayout } from "@src/pages/Layout.jsx";
 import { useLocalStorage } from "@src/services/local-storage/LocalStorageProvider.jsx";
+import type { EditorRouteParams } from "./types.js";
 
 // command-f this repo to find where the layout is called
 export function Layout(props: { children: JSXElement }) {
@@ -150,7 +151,10 @@ function HasChangesAction() {
 			});
 		}
 		setIsLoading(true);
-		const result = await pushChanges(currentPageContext(), localStorage.user);
+		const result = await pushChanges(
+			currentPageContext.routeParams as EditorRouteParams,
+			localStorage.user
+		);
 		setIsLoading(false);
 		if (result.isErr) {
 			return showToast({

--- a/source-code/website/src/pages/editor/state.ts
+++ b/source-code/website/src/pages/editor/state.ts
@@ -230,7 +230,8 @@ async function readInlangConfig(): Promise<InlangConfigSchema | undefined> {
 		"data:application/javascript;base64," + btoa(file.toString());
 
 	const module = await import(/* @vite-ignore */ withMimeType);
-	return module.config({ ...environmentFunctions });
+	const initialized = await module.config({ ...environmentFunctions });
+	return initialized;
 }
 
 async function readBundles(config: InlangConfigSchema) {

--- a/source-code/website/src/pages/editor/state.ts
+++ b/source-code/website/src/pages/editor/state.ts
@@ -31,7 +31,6 @@ import { createAuthHeader } from "@src/services/auth/index.js";
  * for simplicity.
  */
 export function StateProvider(props: { children: JSXElement }) {
-	console.log("calling state provider ", new Date());
 	const [localStorage] = useLocalStorage();
 
 	// re-fetched if currentPageContext changes
@@ -44,10 +43,6 @@ export function StateProvider(props: { children: JSXElement }) {
 		}),
 		cloneRepository
 	);
-
-	createEffect(() => {
-		console.log(currentPageContext.routeParams, new Date());
-	});
 
 	// re-fetched if respository has been cloned
 	[inlangConfig] = createResource(repositoryIsCloned, readInlangConfig);

--- a/source-code/website/src/renderer/state.ts
+++ b/source-code/website/src/renderer/state.ts
@@ -1,4 +1,3 @@
-import { Accessor, createSignal, Setter } from "solid-js";
 import { createStore, SetStoreFunction } from "solid-js/store";
 import type { PageContext, PageContextRenderer } from "./types.js";
 
@@ -11,7 +10,7 @@ import type { PageContext, PageContextRenderer } from "./types.js";
  * page context you are accessing is the `PageContextRenderer`,
  * use a type cast `as PageContextRenderer`.
  */
-export const [currentPageContext, setCurrentPageContext] = createSignal() as [
-	Accessor<PageContext>,
-	Setter<PageContextRenderer>
+export const [currentPageContext, setCurrentPageContext] = createStore({}) as [
+	PageContext,
+	SetStoreFunction<PageContextRenderer>
 ];

--- a/source-code/website/src/services/auth/oauth-redirect.page.tsx
+++ b/source-code/website/src/services/auth/oauth-redirect.page.tsx
@@ -6,6 +6,7 @@ import {
 import { Layout } from "@src/pages/Layout.jsx";
 import MaterialSymbolsCheckCircleRounded from "~icons/material-symbols/check-circle-rounded";
 import MaterialSymbolsArrowBackRounded from "~icons/material-symbols/arrow-back-rounded";
+import type { PageHead } from "@src/renderer/types.js";
 
 export type PageProps = {
 	error?: string;
@@ -13,6 +14,11 @@ export type PageProps = {
 		user: NonNullable<LocalStorageSchema["user"]>;
 	};
 };
+
+export const Head: PageHead = () => ({
+	title: "Auth redirect",
+	description: "Redirects to inlang.",
+});
 
 /**
  * The GitHub web application flow redirects to this page.


### PR DESCRIPTION
Cloning a repository has been called 3 times in a row instead of once. This PR introduces two fixes: 

1. The currentPageContext is a store now instead of a signal. 
2. Signals that clone depend on are now batched. 

The commits have detailed explanations. 

<a href="https://gitpod.io/#https://github.com/inlang/inlang/pull/213"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

