### PR TITLE
243-fix-telefunc

### DIFF
--- a/source-code/core/src/config/schema.ts
+++ b/source-code/core/src/config/schema.ts
@@ -44,7 +44,7 @@ export type Config = {
 		resources: ast.Resource[];
 	}) => Promise<void>;
 	/**
-	 * WARNING: Experimental properties are not required and
+	 * WARNING: Experimental properties are not required,
 	 * can change at any time and do not lead to a MAJOR version bump.
 	 *
 	 * Read more under https://inlang.com/documentation/breaking-changes

--- a/source-code/core/src/config/schema.ts
+++ b/source-code/core/src/config/schema.ts
@@ -43,6 +43,13 @@ export type Config = {
 		config: Config;
 		resources: ast.Resource[];
 	}) => Promise<void>;
+	/**
+	 * WARNING: Experimental properties are not required and
+	 * can change at any time and do not lead to a MAJOR version bump.
+	 *
+	 * Read more under https://inlang.com/documentation/breaking-changes
+	 */
+	// experimental?: {};
 	// ideExtension?: {
 	// 	/**
 	// 	 * Defines when a message is referenced.

--- a/source-code/website/src/server/main.ts
+++ b/source-code/website/src/server/main.ts
@@ -81,7 +81,7 @@ if (isProduction) {
 app.all(
 	"/_telefunc",
 	// Parse & make HTTP request body available at `req.body` (required by telefunc)
-	app.use(express.text()),
+	express.text(),
 	// handle the request
 	(request, response, next) => {
 		telefunc({


### PR DESCRIPTION
The middleware `express.text()` has previously been used in a global context with `app.use(express.text())`. Using the middleware in a global context is not desired as the middleware is telefunc specific. Upon moving the middleware in into the telefunc route "/_telefunc", `app.use()` has not been removed. The latter led to a silent drop in executing telefunc functions.

<a href="https://gitpod.io/#https://github.com/inlang/inlang/pull/244"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

