### PR TITLE
Feature: Secure against CSRF with same site "strict" for the session cookie

### DIFF
--- a/source-code/website/src/server/main.ts
+++ b/source-code/website/src/server/main.ts
@@ -54,6 +54,7 @@ app.use(
     httpOnly: true,
     // secure: isProduction ? true : false,
     // domain: isProduction ? "inlang.com" : undefined,
+    sameSite: "strict",
     secret: env.COOKIE_SECRET,
     maxAge: 7 * 24 * 3600 * 1000, // 1 week
   })


### PR DESCRIPTION
Requests initiated from other sites (domain + port), rather than the cookie setting one (inlang.com / localhost) will no longer contain the session cookie. This prevents attackers from triggering actions, on behalf of the user. CSRF can be achieved by fooling the user into unintentionally triggering an action, by klicking on a misleading link or submitting a disguised form. 

**Important**: Redirection flows will weaken the protection induced by this change. 
Example: User deletion can be triggered by /users/:id/delete and also by the deprecated route /users/delete/:id which redirects to /users/:id/delete. The redirection to the actual working route will in this case be initiated by the inlang api and will hence contain the session cookie. User deletion would then be CSRF vulnerable.

CSRF example: https://guides.codepath.com/websecurity/Cross-Site-Request-Forgery#csrf-post-request-attack