### PR TITLE
configurable pre-commit behavior

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,11 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run lint-staged
+# load env variables from '.env' file
+export $(grep -v '^#' .env)
+
+# run lint-staged if enabled
+if [ "$ENABLE_PRE_COMMIT_HOOK" = "true" ]
+then
+	npm run lint-staged
+fi

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,9 @@
 {
 	"editor.formatOnSave": true,
 	"editor.defaultFormatter": "esbenp.prettier-vscode",
+	"editor.codeActionsOnSave": {
+		"source.fixAll": true
+	},
 	"gitlens.showWelcomeOnInstall": false,
 	"gitlens.showWhatsNewAfterUpgrades": false,
 	"gitlens.plusFeatures.enabled": false,


### PR DESCRIPTION
This PR:
 - will fix all auto-fixable lint errors when a file gets saved
 - disables the pre-commit hook per default
   if someone prefers to have lint-staged enabled he can create a .env file with ENABLE_PRE_COMMIT_HOOK=true.