### PR TITLE
Set up continuous deployment for ide-extension

### DIFF
--- a/.github/workflows/publish-core-to-npm.yml
+++ b/.github/workflows/publish-core-to-npm.yml
@@ -1,3 +1,5 @@
+name: Publish @inlang/core to NPM
+
 on:
   push:
     paths:

--- a/.github/workflows/publish-ide-extension-to-marketplace.yml
+++ b/.github/workflows/publish-ide-extension-to-marketplace.yml
@@ -1,0 +1,34 @@
+name: Publish @inlang/ide-extension to VSCode Marketplace
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: "npm-cache-for-@inlang/ide-extension"
+      - name: Install dependencies
+        run: npm ci
+      - name: Build project
+        run: npm run build
+      - name: Build VSCode extension package
+        run: npm run package -w source-code/ide-extension
+      - name: Publish to VSCode Marketplace
+        run: vsce publish -p ${{secrets.VSCE_TOKEN}}
+        working-directory: ./source-code/ide-extension
+        env:
+          VSCE_TOKEN: ${{secrets.VSCE_TOKEN}}
+      - name: Publish to OpenVSX
+        run: ovsx publish -p ${{secrets.OVSX_TOKEN}}
+        working-directory: ./source-code/ide-extension
+        env:
+          OVSX_TOKEN: ${{secrets.OVSX_TOKEN}}

--- a/.github/workflows/publish-ide-extension-to-marketplace.yml
+++ b/.github/workflows/publish-ide-extension-to-marketplace.yml
@@ -23,12 +23,7 @@ jobs:
       - name: Build VSCode extension package
         run: npm run package -w source-code/ide-extension
       - name: Publish to VSCode Marketplace
-        run: vsce publish -p ${{secrets.VSCE_TOKEN}}
+        run: vsce publish -p ${{secrets.VSCODE_MARKETPLACE_TOKEN}}
         working-directory: ./source-code/ide-extension
         env:
-          VSCE_TOKEN: ${{secrets.VSCE_TOKEN}}
-      - name: Publish to OpenVSX
-        run: ovsx publish -p ${{secrets.OVSX_TOKEN}}
-        working-directory: ./source-code/ide-extension
-        env:
-          OVSX_TOKEN: ${{secrets.OVSX_TOKEN}}
+          VSCODE_MARKETPLACE_TOKEN: ${{secrets.VSCODE_MARKETPLACE_TOKEN}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1457,10 +1457,6 @@
 			"resolved": "source-code/git-sdk",
 			"link": true
 		},
-		"node_modules/@inlang/ide-extension": {
-			"resolved": "source-code/ide-extension",
-			"link": true
-		},
 		"node_modules/@inlang/website": {
 			"resolved": "source-code/website",
 			"link": true
@@ -3152,9 +3148,9 @@
 			}
 		},
 		"node_modules/@vscode/vsce": {
-			"version": "2.17.0",
-			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.17.0.tgz",
-			"integrity": "sha512-W4HN5MtTVj/mroQU1d82bUEeWM3dUykMFnMYZPtZ6jrMiHN1PUoN3RGcS896N0r2rIq8KpWDtufcQHgK8VfgpA==",
+			"version": "2.18.0",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.18.0.tgz",
+			"integrity": "sha512-tUA3XoKx5xjoi3EDcngk0VUYMhvfXLhS4s7CntpLPh1qtLYtgSCexTIMUHkCy6MqyozRW98bdW3a2yHPEADRnQ==",
 			"dev": true,
 			"dependencies": {
 				"azure-devops-node-api": "^11.0.1",
@@ -3163,6 +3159,7 @@
 				"commander": "^6.1.0",
 				"glob": "^7.0.6",
 				"hosted-git-info": "^4.0.2",
+				"jsonc-parser": "^3.2.0",
 				"leven": "^3.1.0",
 				"markdown-it": "^12.3.2",
 				"mime": "^1.3.4",
@@ -7808,6 +7805,10 @@
 			"dev": true,
 			"optional": true
 		},
+		"node_modules/inlang": {
+			"resolved": "source-code/ide-extension",
+			"link": true
+		},
 		"node_modules/inline-style-parser": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
@@ -9956,6 +9957,44 @@
 			"resolved": "https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz",
 			"integrity": "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==",
 			"dev": true
+		},
+		"node_modules/ovsx": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/ovsx/-/ovsx-0.8.0.tgz",
+			"integrity": "sha512-W1U7lgBIbhSB1DcqyGKeenKzmwWYY78SkWd+BUKKyLyqN6w39Uekdr0PKAM7dyBGb0JLtLE7d86A1jJVn8bEng==",
+			"dev": true,
+			"dependencies": {
+				"@vscode/vsce": "^2.15.0",
+				"commander": "^6.1.0",
+				"follow-redirects": "^1.14.6",
+				"is-ci": "^2.0.0",
+				"leven": "^3.1.0",
+				"tmp": "^0.2.1"
+			},
+			"bin": {
+				"ovsx": "lib/ovsx"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/ovsx/node_modules/ci-info": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+			"dev": true
+		},
+		"node_modules/ovsx/node_modules/is-ci": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+			"dev": true,
+			"dependencies": {
+				"ci-info": "^2.0.0"
+			},
+			"bin": {
+				"is-ci": "bin.js"
+			}
 		},
 		"node_modules/p-filter": {
 			"version": "2.1.0",
@@ -13638,7 +13677,7 @@
 			}
 		},
 		"source-code/ide-extension": {
-			"name": "@inlang/ide-extension",
+			"name": "inlang",
 			"version": "0.4.3",
 			"dependencies": {
 				"@inlang/core": "*",
@@ -13651,11 +13690,12 @@
 				"@rollup/plugin-typescript": "^11.0.0",
 				"@types/throttle-debounce": "^5.0.0",
 				"@types/vscode": "^1.75.0",
-				"@vscode/vsce": "^2.17.0",
+				"@vscode/vsce": "^2.18.0",
+				"ovsx": "^0.8.0",
 				"rollup": "^3.14.0"
 			},
 			"engines": {
-				"vscode": "^1.74.1"
+				"vscode": "^1.75.0"
 			}
 		},
 		"source-code/ide-extension/node_modules/node-fetch": {
@@ -14940,42 +14980,6 @@
 			"requires": {
 				"isomorphic-git": "^1.21.0",
 				"memfs": "^3.4.9"
-			}
-		},
-		"@inlang/ide-extension": {
-			"version": "file:source-code/ide-extension",
-			"requires": {
-				"@inlang/core": "*",
-				"@rollup/plugin-commonjs": "^24.0.1",
-				"@rollup/plugin-node-resolve": "^15.0.1",
-				"@rollup/plugin-typescript": "^11.0.0",
-				"@types/throttle-debounce": "^5.0.0",
-				"@types/vscode": "^1.75.0",
-				"@vscode/vsce": "^2.17.0",
-				"node-fetch": "^3.3.0",
-				"rollup": "^3.14.0",
-				"throttle-debounce": "^5.0.0"
-			},
-			"dependencies": {
-				"node-fetch": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
-					"integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
-					"requires": {
-						"data-uri-to-buffer": "^4.0.0",
-						"fetch-blob": "^3.1.4",
-						"formdata-polyfill": "^4.0.10"
-					}
-				},
-				"rollup": {
-					"version": "3.14.0",
-					"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.14.0.tgz",
-					"integrity": "sha512-o23sdgCLcLSe3zIplT9nQ1+r97okuaiR+vmAPZPTDYB7/f3tgWIYNyiQveMsZwshBT0is4eGax/HH83Q7CG+/Q==",
-					"dev": true,
-					"requires": {
-						"fsevents": "~2.3.2"
-					}
-				}
 			}
 		},
 		"@inlang/website": {
@@ -16377,9 +16381,9 @@
 			}
 		},
 		"@vscode/vsce": {
-			"version": "2.17.0",
-			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.17.0.tgz",
-			"integrity": "sha512-W4HN5MtTVj/mroQU1d82bUEeWM3dUykMFnMYZPtZ6jrMiHN1PUoN3RGcS896N0r2rIq8KpWDtufcQHgK8VfgpA==",
+			"version": "2.18.0",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.18.0.tgz",
+			"integrity": "sha512-tUA3XoKx5xjoi3EDcngk0VUYMhvfXLhS4s7CntpLPh1qtLYtgSCexTIMUHkCy6MqyozRW98bdW3a2yHPEADRnQ==",
 			"dev": true,
 			"requires": {
 				"azure-devops-node-api": "^11.0.1",
@@ -16388,6 +16392,7 @@
 				"commander": "^6.1.0",
 				"glob": "^7.0.6",
 				"hosted-git-info": "^4.0.2",
+				"jsonc-parser": "^3.2.0",
 				"keytar": "^7.7.0",
 				"leven": "^3.1.0",
 				"markdown-it": "^12.3.2",
@@ -19732,6 +19737,43 @@
 			"dev": true,
 			"optional": true
 		},
+		"inlang": {
+			"version": "file:source-code/ide-extension",
+			"requires": {
+				"@inlang/core": "*",
+				"@rollup/plugin-commonjs": "^24.0.1",
+				"@rollup/plugin-node-resolve": "^15.0.1",
+				"@rollup/plugin-typescript": "^11.0.0",
+				"@types/throttle-debounce": "^5.0.0",
+				"@types/vscode": "^1.75.0",
+				"@vscode/vsce": "^2.18.0",
+				"node-fetch": "^3.3.0",
+				"ovsx": "^0.8.0",
+				"rollup": "^3.14.0",
+				"throttle-debounce": "^5.0.0"
+			},
+			"dependencies": {
+				"node-fetch": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
+					"integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
+					"requires": {
+						"data-uri-to-buffer": "^4.0.0",
+						"fetch-blob": "^3.1.4",
+						"formdata-polyfill": "^4.0.10"
+					}
+				},
+				"rollup": {
+					"version": "3.14.0",
+					"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.14.0.tgz",
+					"integrity": "sha512-o23sdgCLcLSe3zIplT9nQ1+r97okuaiR+vmAPZPTDYB7/f3tgWIYNyiQveMsZwshBT0is4eGax/HH83Q7CG+/Q==",
+					"dev": true,
+					"requires": {
+						"fsevents": "~2.3.2"
+					}
+				}
+			}
+		},
 		"inline-style-parser": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
@@ -21308,6 +21350,37 @@
 			"resolved": "https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz",
 			"integrity": "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==",
 			"dev": true
+		},
+		"ovsx": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/ovsx/-/ovsx-0.8.0.tgz",
+			"integrity": "sha512-W1U7lgBIbhSB1DcqyGKeenKzmwWYY78SkWd+BUKKyLyqN6w39Uekdr0PKAM7dyBGb0JLtLE7d86A1jJVn8bEng==",
+			"dev": true,
+			"requires": {
+				"@vscode/vsce": "^2.15.0",
+				"commander": "^6.1.0",
+				"follow-redirects": "^1.14.6",
+				"is-ci": "^2.0.0",
+				"leven": "^3.1.0",
+				"tmp": "^0.2.1"
+			},
+			"dependencies": {
+				"ci-info": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+					"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+					"dev": true
+				},
+				"is-ci": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+					"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+					"dev": true,
+					"requires": {
+						"ci-info": "^2.0.0"
+					}
+				}
+			}
 		},
 		"p-filter": {
 			"version": "2.1.0",

--- a/source-code/ide-extension/.vscodeignore
+++ b/source-code/ide-extension/.vscodeignore
@@ -8,6 +8,7 @@ src/**
 **/*.map
 **/*.ts
 
+node_modules/**
 example/**
 ../../**
 ../**

--- a/source-code/ide-extension/package.json
+++ b/source-code/ide-extension/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "inlang",
+	"name": "@inlang/ide-extension",
 	"private": true,
 	"displayName": "inlang",
 	"type": "module",

--- a/source-code/ide-extension/package.json
+++ b/source-code/ide-extension/package.json
@@ -1,10 +1,10 @@
 {
-	"name": "@inlang/ide-extension",
+	"name": "inlang",
 	"private": true,
 	"displayName": "inlang",
 	"type": "module",
 	"description": "i18n extension that makes you more productive.",
-	"publisher": "Inlang",
+	"publisher": "inlang",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/inlang/inlang.git"
@@ -12,7 +12,7 @@
 	"icon": "assets/icon.png",
 	"version": "0.4.3",
 	"engines": {
-		"vscode": "^1.74.1"
+		"vscode": "^1.75.0"
 	},
 	"categories": [
 		"Other",
@@ -29,10 +29,10 @@
 		]
 	},
 	"scripts": {
-		"_vscode:prepublish": "npm run build",
-		"_build": "rollup --config",
+		"build": "rollup --config",
 		"dev": "rollup --config --watch",
-		"_package": "npx vsce package",
+		"package": "npx vsce package",
+		"prepackage": "node ./scripts/preparePackage.js",
 		"---- TEST ----------------------------------------------------------": "",
 		"test": "vitest run --coverage",
 		"---- LINT ----------------------------------------------------------": "",
@@ -54,7 +54,8 @@
 		"@rollup/plugin-typescript": "^11.0.0",
 		"@types/throttle-debounce": "^5.0.0",
 		"@types/vscode": "^1.75.0",
-		"@vscode/vsce": "^2.17.0",
+		"@vscode/vsce": "^2.18.0",
+		"ovsx": "^0.8.0",
 		"rollup": "^3.14.0"
 	},
 	"activationEvents": [

--- a/source-code/ide-extension/package.json
+++ b/source-code/ide-extension/package.json
@@ -34,7 +34,7 @@
 		"dev": "rollup --config --watch",
 		"_package": "npx vsce package",
 		"---- TEST ----------------------------------------------------------": "",
-		"_test": "vitest run --coverage",
+		"test": "vitest run --coverage",
 		"---- LINT ----------------------------------------------------------": "",
 		"lint": "cd ../.. && npm run lint:base ./source-code/ide-extension",
 		"lint:fix": "cd ../.. && npm run lint:fix:base ./source-code/ide-extension",

--- a/source-code/ide-extension/scripts/preparePackage.js
+++ b/source-code/ide-extension/scripts/preparePackage.js
@@ -1,7 +1,7 @@
-import("node:fs").then((fs) => {
-	// change name of package
-	// see https://github.com/microsoft/vscode-vsce/issues/186
-	const packageJson = JSON.parse(fs.readFileSync("./package.json"))
-	packageJson.name = "vs-code-extension"
-	fs.writeFileSync("./package.json", JSON.stringify(packageJson, undefined, 2))
-})
+import fs from "node:fs"
+
+// change name of package
+// see https://github.com/microsoft/vscode-vsce/issues/186
+const packageJson = JSON.parse(fs.readFileSync("./package.json"))
+packageJson.name = "vs-code-extension"
+fs.writeFileSync("./package.json", JSON.stringify(packageJson, undefined, 2))

--- a/source-code/ide-extension/scripts/preparePackage.js
+++ b/source-code/ide-extension/scripts/preparePackage.js
@@ -2,6 +2,6 @@ import("node:fs").then((fs) => {
 	// change name of package
 	// see https://github.com/microsoft/vscode-vsce/issues/186
 	const packageJson = JSON.parse(fs.readFileSync("./package.json"))
-	packageJson.name = "inlang"
+	packageJson.name = "vs-code-extension"
 	fs.writeFileSync("./package.json", JSON.stringify(packageJson, undefined, 2))
 })

--- a/source-code/ide-extension/scripts/preparePackage.js
+++ b/source-code/ide-extension/scripts/preparePackage.js
@@ -1,0 +1,7 @@
+import('node:fs').then((fs) => {
+  // change name of package
+  // see https://github.com/microsoft/vscode-vsce/issues/186
+  const packageJson = JSON.parse(fs.readFileSync('./package.json'));
+  packageJson.name = 'inlang';
+  fs.writeFileSync('./package.json', JSON.stringify(packageJson, undefined, 2));
+});

--- a/source-code/ide-extension/scripts/preparePackage.js
+++ b/source-code/ide-extension/scripts/preparePackage.js
@@ -1,7 +1,7 @@
-import('node:fs').then((fs) => {
-  // change name of package
-  // see https://github.com/microsoft/vscode-vsce/issues/186
-  const packageJson = JSON.parse(fs.readFileSync('./package.json'));
-  packageJson.name = 'inlang';
-  fs.writeFileSync('./package.json', JSON.stringify(packageJson, undefined, 2));
-});
+import("node:fs").then((fs) => {
+	// change name of package
+	// see https://github.com/microsoft/vscode-vsce/issues/186
+	const packageJson = JSON.parse(fs.readFileSync("./package.json"))
+	packageJson.name = "inlang"
+	fs.writeFileSync("./package.json", JSON.stringify(packageJson, undefined, 2))
+})


### PR DESCRIPTION
## Learnings 

### No scoped extension names
VSCodes Marketplace doesn't support scoped names like `@inlang/ide-extension`. `vsce` infers the name from `package.json`. This leads to: `ERROR  Invalid extension name '@inlang/ide-extension'`.

https://github.com/microsoft/vscode-vsce/issues/186

### VSCE adds .js to entry points

Because inlang are ESMs, but ide-extension cannot be ESM, we use CommonJS for it with `.cjs` extension to declare this. Prior `2.18.0` of `vsce` it added `.js` to the entrypoint and eventually searching for a `main.cjs.js` file. Luckily this is fixed in the most recent version.

https://github.com/microsoft/vscode-vsce/pull/825

### Monorepo 

`vsce` tries to package parent directories as well. This isn't necessary and leads to errors (naming collisions in node_modules), so they should be ignored inside `.vscodeignore`:

```
../../**
../**
```