### PR TITLE
refactor: use minimum config schema, remove env from lint

### DIFF
--- a/.changeset/brown-rice-draw.md
+++ b/.changeset/brown-rice-draw.md
@@ -1,0 +1,7 @@
+---
+"@inlang/core": minor
+---
+
+refactor: combined multiple lint query functions in one
+
+https://github.com/inlang/inlang/pull/453

--- a/source-code/core/src/lint/README.md
+++ b/source-code/core/src/lint/README.md
@@ -27,10 +27,8 @@ You can use the `lint` function provided by `@inlang/core/lint`.
 ```ts
 import { lint } from "@inlang/core/eslint"
 
-const config = {} // the resolved config from `inlang.config.js`
-const env = {} // the environment functions
-
-const result = await lint(config, env)
+// lint takes a subset of the inlang.config.js file and the resources as arguments
+const result = await lint({ config, resources })
 ```
 
 The promise returns an `Array` of all `Resources`. The nodes of the `Resource` and it's children can have a `lint` attribute attached. If present, the `lint` attribute will contain an `Array` of `LintResults`. To make it easier to see if one of the lint rules reported a violation, `inlang` provides some [utility functions](#utility-functions).
@@ -163,8 +161,7 @@ The `createLintRule` expects 3 parameters.
 3. A callback function that gets passed the settings of the lint rule. It must return an object with the following properties:
 
    - `setup`: A function that can be used to open connections or setup other stuff that will be used during the lint process.\
-      The `setup` function gets called with the following parameter: `{ env, referenceLanguage, languages, context }` where
-     - `env` are the [environment functions](https://inlang.com/documentation/environment-functions) used to e.g. be able to import modules.
+      The `setup` function gets called with the following parameter: `{ referenceLanguage, languages, context }` where
      - `referenceLanguage` is the reference language of ths repository.
      - `languages` is an array of the supported languages.
      - `context` is the context of the linting process, that provides utility functions to report lint violations to any node.

--- a/source-code/core/src/lint/README.md
+++ b/source-code/core/src/lint/README.md
@@ -35,35 +35,19 @@ The promise returns an `Array` of all `Resources`. The nodes of the `Resource` a
 
 #### utility functions
 
-Utility functions provide an easy way to check if a `Resource` has a `lint` attribute. All utility functions can be imported from `@inlang/core/lint`. Per default nodes are checked recursively for the `lint` attribute. You can pass `false` as the last argument to just check a node without it's children.
+Utility functions provide an easy way to check if a `Resource` has a `lint` attribute. All utility functions can be imported from `@inlang/core/lint`. Per default nodes are checked recursively for the `lint` attribute. You can pass `nested: false` in the options to check a node without it's children.
 
 Example:
 
 ```ts
-import { getLintErrors } from "@inlang/core/lint"
+import { getLintReports } from "@inlang/core/lint"
 
 // recursively check all nodes for lint errors
-const errors = getLintErrors(lintedResource)
+const errors = getLintReports(lintedResource, { level: "error" })
 
 // just check a single node for lint errors
-const errors = getLintErrors(lintedResource, false)
+const errors = getLintReports(lintedResource, { level: "error", nested: false })
 ```
-
-Here is a list of all provided utility functions:
-
-- **`getLintReports`**: Extracts all lint reports that are present on the given node.
-- **`getLintReportsByLevel`**: Extracts all lint reports with a certain lint level that are present on the given node.
-- **`getLintErrors`**: Extracts all lint reports with the 'error' lint level that are present on the given node.
-- **`getLintWarnings`**: Extracts all lint reports with the 'warn' lint level that are present on the given node.
-- **`getLintReportsWithId`**: Extracts all lint reports with a certain lint id that are present on the given node.
-- **`getLintErrorsWithId`**: Extracts all lint reports with a certain lint id and the 'error' lint level that are present on the given node.
-- **`getLintWarningsWithId`**: Extracts all lint reports with a certain lint id and the 'warn' lint level that are present on the given node.
-- **`hasLintReports`**: Checks if a given node has lint reports attached to it.
-- **`hasLintErrors`**: Checks if a given node has lint reports with the 'error' lint level attached to it.
-- **`hasLintWarnings`**: Checks if a given node has lint reports with the 'warn' lint level attached to it.
-- **`hasLintReportsWithId`**: Checks if a given node has lint reports with a certain lint id attached to it.
-- **`hasLintErrorsWithId`**: Checks if a given node has lint reports with a certain lint id and the 'error' lint level attached to it.
-- **`hasLintWarningsWithId`**: Checks if a given node has lint reports with a certain lint id and the 'warn' lint level attached to it.
 
 ## Configuration
 

--- a/source-code/core/src/lint/index.ts
+++ b/source-code/core/src/lint/index.ts
@@ -1,5 +1,5 @@
 export { lint } from "./linter.js"
-export * from "./query.js"
+export { getLintReports, hasLintReports } from "./query.js"
 export { type Context, parseLintConfigArguments } from "./context.js"
 export { createLintRule, type LintRule, type LintRuleInitializer, type LintRuleId } from "./rule.js"
 export { createLintRuleCollection, type RuleCollectionInitializer } from "./ruleCollection.js"

--- a/source-code/core/src/lint/linter.test-d.ts
+++ b/source-code/core/src/lint/linter.test-d.ts
@@ -1,13 +1,12 @@
-/* eslint-disable unicorn/no-null */
 import { expectType } from "tsd"
-import type { Config, EnvironmentFunctions } from "../config/schema.js"
+import type { Config } from "../config/schema.js"
 import type { LintedResource } from "./context.js"
+import type * as ast from "../ast/index.js"
 import { lint } from "./linter.js"
 
-const config: Config = null as any
-const env: EnvironmentFunctions = null as any
+const config: Config = undefined as any
+const resources: ast.Resource[] = undefined as any
 
-expectType<Parameters<typeof lint>[0]>(config)
-expectType<Parameters<typeof lint>[1]>(env)
+expectType<Parameters<typeof lint>[0]["config"]>(config)
 
-expectType<LintedResource[] | undefined>(await lint(config, env))
+expectType<LintedResource[] | undefined>(await lint({ config, resources }))

--- a/source-code/core/src/lint/linter.test.ts
+++ b/source-code/core/src/lint/linter.test.ts
@@ -82,6 +82,32 @@ describe("lint", async () => {
 		vi.resetAllMocks()
 	})
 
+	test("it should be immutable and not modify the resources passed as an argument", async () => {
+		const cloned = structuredClone(referenceResource)
+		let context: Context
+		const result = await doLint(
+			[
+				{
+					id: "inlang.someError",
+					level: "error",
+					setup: (args) => {
+						context = args.context
+					},
+					visitors: {
+						Resource: ({ target }) => {
+							if (target) {
+								context.report({ node: target, message: "Error" })
+							}
+						},
+					},
+				},
+			],
+			[cloned],
+		)
+		expect(cloned).toStrictEqual(referenceResource)
+		expect(result).not.toStrictEqual(cloned)
+	})
+
 	describe("rules", async () => {
 		test("should be able to disable rule", async () => {
 			const resources = [referenceResource]

--- a/source-code/core/src/lint/linter.test.ts
+++ b/source-code/core/src/lint/linter.test.ts
@@ -112,11 +112,12 @@ describe("lint", async () => {
 			})
 		})
 
-		test("should not start linting if no rules are specified", async () => {
-			const result = await doLint([], [])
+		test("should return the original resource if no rules are specified", async () => {
+			const resources = [referenceResource]
 
-			expect(result).toBeUndefined()
-			expect(console.warn).toHaveBeenCalledTimes(1)
+			const result = await doLint([], resources)
+
+			expect(result).toEqual(resources)
 		})
 
 		test("should process all 'Resources'", async () => {

--- a/source-code/core/src/lint/linter.ts
+++ b/source-code/core/src/lint/linter.ts
@@ -16,11 +16,10 @@ const getResourceForLanguage = (resources: Resource[], language: string) =>
 export const lint = async (args: {
 	config: Pick<Config, "lint" | "languages" | "referenceLanguage">
 	resources: Resource[]
-}) => {
+}): Promise<LintedResource[]> => {
 	const { referenceLanguage, languages, lint } = args.config
 	if (lint === undefined || lint.rules.length === 0) {
-		console.warn("No lint rules specified. Aborting ...")
-		return
+		return args.resources
 	}
 	const reference = getResourceForLanguage(args.resources, referenceLanguage)
 

--- a/source-code/core/src/lint/linter.ts
+++ b/source-code/core/src/lint/linter.ts
@@ -18,10 +18,12 @@ export const lint = async (args: {
 	resources: Resource[]
 }): Promise<LintedResource[]> => {
 	const { referenceLanguage, languages, lint } = args.config
+	// linting the resources should not modify args.resources.
+	const resources = structuredClone(args.resources)
 	if (lint === undefined || lint.rules.length === 0) {
 		return args.resources
 	}
-	const reference = getResourceForLanguage(args.resources, referenceLanguage)
+	const reference = getResourceForLanguage(resources, referenceLanguage)
 
 	await Promise.all(
 		lint.rules.flat().map((lintRule) =>
@@ -30,12 +32,12 @@ export const lint = async (args: {
 				referenceLanguage,
 				languages,
 				reference,
-				resources: args.resources,
+				resources,
 			}).catch((e) => console.error(`Unexpected error in lint rule '${lintRule.id}':`, e)),
 		),
 	)
 
-	return args.resources as LintedResource[]
+	return resources as LintedResource[]
 }
 
 const processLintRule = async ({

--- a/source-code/core/src/lint/linter.ts
+++ b/source-code/core/src/lint/linter.ts
@@ -25,7 +25,7 @@ export const lint = async (args: {
 	const reference = getResourceForLanguage(args.resources, referenceLanguage)
 
 	await Promise.all(
-		lint?.rules.flat().map((lintRule) =>
+		lint.rules.flat().map((lintRule) =>
 			processLintRule({
 				lintRule,
 				referenceLanguage,

--- a/source-code/core/src/lint/output.ts
+++ b/source-code/core/src/lint/output.ts
@@ -7,7 +7,7 @@ export const print = (resource: LintedResource) => {
 	const separator = `Resource['${resource.languageTag.name}']`
 	console.info(separator)
 
-	const reports = getLintReports(resource, false)
+	const reports = getLintReports(resource, { nested: false })
 	for (const report of reports) {
 		printReport(report, "info")
 	}
@@ -23,7 +23,7 @@ const printMessage = (message: LintedMessage, prefix: string) => {
 	const separator = `${prefix} -> Message['${message.id.name}']`
 	console.info(separator)
 
-	const reports = getLintReports(message, false)
+	const reports = getLintReports(message, { nested: false })
 	for (const report of reports) {
 		printReport(report, "info")
 	}
@@ -34,7 +34,7 @@ const printMessage = (message: LintedMessage, prefix: string) => {
 const printPattern = (pattern: LintedPattern) => {
 	if (!hasLintReports(pattern)) return
 
-	const reports = getLintReports(pattern, false)
+	const reports = getLintReports(pattern, { nested: false })
 	for (const report of reports) {
 		printReport(report, "info")
 	}

--- a/source-code/core/src/lint/query.test.ts
+++ b/source-code/core/src/lint/query.test.ts
@@ -6,21 +6,7 @@ import type {
 	LintLevel,
 	LintReport,
 } from "./context.js"
-import {
-	getLintErrors,
-	getLintErrorsWithId,
-	getLintReports,
-	getLintReportsByLevel,
-	getLintReportsWithId,
-	getLintWarnings,
-	getLintWarningsWithId,
-	hasLintErrors,
-	hasLintErrorsWithId,
-	hasLintReports,
-	hasLintReportsWithId,
-	hasLintWarnings,
-	hasLintWarningsWithId,
-} from "./query.js"
+import { getLintReports, hasLintReports } from "./query.js"
 import type { LintableNode, LintRuleId } from "./rule.js"
 
 const createReport = (id: LintRuleId, level: LintLevel) =>
@@ -92,598 +78,64 @@ const resource = createLintedResource(
 	message3,
 )
 
-const resource2 = createLintedResource("de", undefined, message3)
-
-// --------------------------------------------------------------------------------------------------------------------
-
 describe("getLintReports", async () => {
 	describe("'Resource'", async () => {
 		test("nested", async () => {
-			const reports = getLintReports(resource, true)
+			const reports = getLintReports(resource, { nested: true })
 
 			expect(reports).toHaveLength(12)
 		})
 
 		test("not nested", async () => {
-			const reports = getLintReports(resource, false)
+			const reports = getLintReports(resource, { nested: false })
 
 			expect(reports).toHaveLength(3)
 		})
-	})
 
-	describe("'Message'", async () => {
-		test("nested", async () => {
-			const reports = getLintReports(message, true)
-
+		test("by level nested", async () => {
+			const reports = getLintReports(resource, { nested: true, level: "error" })
 			expect(reports).toHaveLength(6)
 		})
 
-		test("not nested", async () => {
-			const reports = getLintReports(message, false)
-
-			expect(reports).toHaveLength(3)
+		test("by level not nested", async () => {
+			const reports = getLintReports(resource, { nested: false, level: "error" })
+			expect(reports).toHaveLength(2)
 		})
-	})
 
-	describe("'Pattern'", async () => {
-		test("nested", async () => {
-			const reports = getLintReports(pattern, true)
+		test("with id nested", async () => {
+			const reports = getLintReports(resource, { nested: true, id: "id.3" })
 
 			expect(reports).toHaveLength(3)
 		})
 
-		test("not nested", async () => {
-			const reports = getLintReports(pattern, false)
+		test("with id not nested", async () => {
+			const reports = getLintReports(resource, { nested: false, id: "id.3" })
 
-			expect(reports).toHaveLength(3)
+			expect(reports).toHaveLength(1)
+		})
+
+		test("should support an array of nodes", async () => {
+			const reports = getLintReports([resource, message, pattern])
+
+			expect(reports).toHaveLength(21)
+		})
+
+		test("should throw an error if node type does not get handled", async () => {
+			expect(() => hasLintReports({ type: "unknown" } as unknown as LintableNode)).toThrow()
 		})
 	})
 
-	test("should support an array of nodes", async () => {
-		const reports = getLintReports([resource, message, pattern])
-
-		expect(reports).toHaveLength(21)
+	test("Message", async () => {
+		const reports = getLintReports(message)
+		expect(reports).toHaveLength(6)
 	})
 
-	test("should throw an error if node type does not get handled", async () => {
-		expect(() => getLintReports({ type: "unknown" } as unknown as LintableNode)).toThrow()
+	test("'Pattern'", async () => {
+		const reports = getLintReports(pattern)
+		expect(reports).toHaveLength(3)
 	})
 })
 
-// --------------------------------------------------------------------------------------------------------------------
-
-describe("getLintReportsByLevel", async () => {
-	describe("'Resource'", async () => {
-		test("nested", async () => {
-			const reports = getLintReportsByLevel("error", resource, true)
-
-			expect(reports).toHaveLength(6)
-		})
-
-		test("not nested", async () => {
-			const reports = getLintReportsByLevel("error", resource, false)
-
-			expect(reports).toHaveLength(2)
-		})
-	})
-
-	describe("'Message'", async () => {
-		test("nested", async () => {
-			const reports = getLintReportsByLevel("error", message, true)
-
-			expect(reports).toHaveLength(2)
-		})
-
-		test("not nested", async () => {
-			const reports = getLintReportsByLevel("error", message, false)
-
-			expect(reports).toHaveLength(1)
-		})
-	})
-
-	describe("'Pattern'", async () => {
-		test("nested", async () => {
-			const reports = getLintReportsByLevel("error", pattern, true)
-
-			expect(reports).toHaveLength(1)
-		})
-
-		test("not nested", async () => {
-			const reports = getLintReportsByLevel("error", pattern, false)
-
-			expect(reports).toHaveLength(1)
-		})
-	})
-
-	test("should throw an error if node type does not get handled", async () => {
-		expect(() =>
-			getLintReportsByLevel("warn", {
-				type: "unknown",
-			} as unknown as LintableNode),
-		).toThrow()
-	})
-})
-
-describe("getLintErrors", async () => {
-	describe("'Resource'", async () => {
-		test("nested", async () => {
-			const reports = getLintErrors(resource, true)
-
-			expect(reports).toHaveLength(6)
-		})
-
-		test("not nested", async () => {
-			const reports = getLintErrors(resource, false)
-
-			expect(reports).toHaveLength(2)
-		})
-	})
-
-	describe("'Message'", async () => {
-		test("nested", async () => {
-			const reports = getLintErrors(message, true)
-
-			expect(reports).toHaveLength(2)
-		})
-
-		test("not nested", async () => {
-			const reports = getLintErrors(message, false)
-
-			expect(reports).toHaveLength(1)
-		})
-	})
-
-	describe("'Pattern'", async () => {
-		test("nested", async () => {
-			const reports = getLintErrors(pattern, true)
-
-			expect(reports).toHaveLength(1)
-		})
-
-		test("not nested", async () => {
-			const reports = getLintErrors(pattern, false)
-
-			expect(reports).toHaveLength(1)
-		})
-	})
-
-	test("should throw an error if node type does not get handled", async () => {
-		expect(() => getLintErrors({ type: "unknown" } as unknown as LintableNode)).toThrow()
-	})
-})
-
-describe("getLintWarnings", async () => {
-	describe("'Resource'", async () => {
-		test("nested", async () => {
-			const reports = getLintWarnings(resource, true)
-
-			expect(reports).toHaveLength(6)
-		})
-
-		test("not nested", async () => {
-			const reports = getLintWarnings(resource, false)
-
-			expect(reports).toHaveLength(1)
-		})
-	})
-
-	describe("'Message'", async () => {
-		test("nested", async () => {
-			const reports = getLintWarnings(message2, true)
-
-			expect(reports).toHaveLength(1)
-		})
-
-		test("not nested", async () => {
-			const reports = getLintWarnings(message2, false)
-
-			expect(reports).toHaveLength(0)
-		})
-	})
-
-	describe("'Pattern'", async () => {
-		test("nested", async () => {
-			const reports = getLintWarnings(pattern, true)
-
-			expect(reports).toHaveLength(2)
-		})
-
-		test("not nested", async () => {
-			const reports = getLintWarnings(pattern, false)
-
-			expect(reports).toHaveLength(2)
-		})
-	})
-
-	test("should throw an error if node type does not get handled", async () => {
-		expect(() => getLintWarnings({ type: "unknown" } as unknown as LintableNode)).toThrow()
-	})
-})
-
-// --------------------------------------------------------------------------------------------------------------------
-
-describe("getLintReportsWithId", async () => {
-	describe("'Resource'", async () => {
-		test("nested", async () => {
-			const reports = getLintReportsWithId("id.3", resource, true)
-
-			expect(reports).toHaveLength(3)
-		})
-
-		test("not nested", async () => {
-			const reports = getLintReportsWithId("id.3", resource, false)
-
-			expect(reports).toHaveLength(1)
-		})
-	})
-
-	describe("'Message'", async () => {
-		test("nested", async () => {
-			const reports = getLintReportsWithId("id.2", message, true)
-
-			expect(reports).toHaveLength(1)
-		})
-
-		test("not nested", async () => {
-			const reports = getLintReportsWithId("id.2", message, false)
-
-			expect(reports).toHaveLength(0)
-		})
-	})
-
-	describe("'Pattern'", async () => {
-		test("nested", async () => {
-			const reports = getLintReportsWithId("id.1", pattern, true)
-
-			expect(reports).toHaveLength(1)
-		})
-
-		test("not nested", async () => {
-			const reports = getLintReportsWithId("id.1", pattern, false)
-
-			expect(reports).toHaveLength(1)
-		})
-	})
-
-	test("should throw an error if node type does not get handled", async () => {
-		expect(() =>
-			getLintReportsWithId("some.id", {
-				type: "unknown",
-			} as unknown as LintableNode),
-		).toThrow()
-	})
-})
-
-describe("getLintErrorsWithId", async () => {
-	describe("'Resource'", async () => {
-		test("nested", async () => {
-			const reports = getLintErrorsWithId("id.3", resource, true)
-
-			expect(reports).toHaveLength(3)
-		})
-
-		test("not nested", async () => {
-			const reports = getLintErrorsWithId("id.3", resource, false)
-
-			expect(reports).toHaveLength(1)
-		})
-	})
-
-	describe("'Message'", async () => {
-		test("nested", async () => {
-			const reports = getLintErrorsWithId("id.2", message, true)
-
-			expect(reports).toHaveLength(0)
-		})
-
-		test("not nested", async () => {
-			const reports = getLintErrorsWithId("id.2", message, false)
-
-			expect(reports).toHaveLength(0)
-		})
-	})
-
-	describe("'Pattern'", async () => {
-		test("nested", async () => {
-			const reports = getLintErrorsWithId("id.1", pattern, true)
-
-			expect(reports).toHaveLength(1)
-		})
-
-		test("not nested", async () => {
-			const reports = getLintErrorsWithId("id.1", pattern, false)
-
-			expect(reports).toHaveLength(1)
-		})
-	})
-
-	test("should throw an error if node type does not get handled", async () => {
-		expect(() =>
-			getLintErrorsWithId("some.id", {
-				type: "unknown",
-			} as unknown as LintableNode),
-		).toThrow()
-	})
-})
-
-describe("getLintWarningsWithId", async () => {
-	describe("'Resource'", async () => {
-		test("nested", async () => {
-			const reports = getLintWarningsWithId("id.5", resource, true)
-
-			expect(reports).toHaveLength(0)
-		})
-
-		test("not nested", async () => {
-			const reports = getLintWarningsWithId("id.5", resource, false)
-
-			expect(reports).toHaveLength(0)
-		})
-	})
-
-	describe("'Message'", async () => {
-		test("nested", async () => {
-			const reports = getLintWarningsWithId("id.2", message, true)
-
-			expect(reports).toHaveLength(1)
-		})
-
-		test("not nested", async () => {
-			const reports = getLintWarningsWithId("id.2", message, false)
-
-			expect(reports).toHaveLength(0)
-		})
-	})
-
-	describe("'Pattern'", async () => {
-		test("nested", async () => {
-			const reports = getLintWarningsWithId("id.2", pattern, true)
-
-			expect(reports).toHaveLength(1)
-		})
-
-		test("not nested", async () => {
-			const reports = getLintWarningsWithId("id.2", pattern, false)
-
-			expect(reports).toHaveLength(1)
-		})
-	})
-
-	test("should throw an error if node type does not get handled", async () => {
-		expect(() =>
-			getLintWarningsWithId("some.id", {
-				type: "unknown",
-			} as unknown as LintableNode),
-		).toThrow()
-	})
-})
-
-// --------------------------------------------------------------------------------------------------------------------
-
-describe("hasLintReports", async () => {
-	describe("'Resource'", async () => {
-		test("nested", async () => {
-			expect(hasLintReports(resource, true)).toBe(true)
-		})
-
-		test("not nested", async () => {
-			expect(hasLintReports(resource, false)).toBe(true)
-		})
-	})
-
-	describe("'Message'", async () => {
-		test("nested", async () => {
-			expect(hasLintReports(message, true)).toBe(true)
-		})
-
-		test("not nested", async () => {
-			expect(hasLintReports(message, false)).toBe(true)
-		})
-	})
-
-	describe("'Pattern'", async () => {
-		test("nested", async () => {
-			expect(hasLintReports(pattern, true)).toBe(true)
-		})
-
-		test("not nested", async () => {
-			expect(hasLintReports(pattern, false)).toBe(true)
-		})
-	})
-
-	test("should throw an error if node type does not get handled", async () => {
-		expect(() => hasLintReports({ type: "unknown" } as unknown as LintableNode)).toThrow()
-	})
-})
-
-describe("hasLintErrors", async () => {
-	describe("'Resource'", async () => {
-		test("nested", async () => {
-			expect(hasLintErrors(resource, true)).toBe(true)
-		})
-
-		test("not nested", async () => {
-			expect(hasLintErrors(resource, false)).toBe(true)
-		})
-	})
-
-	describe("'Message'", async () => {
-		test("nested", async () => {
-			expect(hasLintErrors(message, true)).toBe(true)
-		})
-
-		test("not nested", async () => {
-			expect(hasLintErrors(message, false)).toBe(true)
-		})
-	})
-
-	describe("'Pattern'", async () => {
-		test("nested", async () => {
-			expect(hasLintErrors(pattern, true)).toBe(true)
-		})
-
-		test("not nested", async () => {
-			expect(hasLintErrors(pattern, false)).toBe(true)
-		})
-	})
-
-	test("should throw an error if node type does not get handled", async () => {
-		expect(() => hasLintErrors({ type: "unknown" } as unknown as LintableNode)).toThrow()
-	})
-})
-
-describe("hasLintWarnings", async () => {
-	describe("'Resource'", async () => {
-		test("nested", async () => {
-			expect(hasLintWarnings(resource, true)).toBe(true)
-		})
-
-		test("not nested", async () => {
-			expect(hasLintWarnings(resource, false)).toBe(true)
-		})
-	})
-
-	describe("'Message'", async () => {
-		test("nested", async () => {
-			expect(hasLintWarnings(message, true)).toBe(true)
-		})
-
-		test("not nested", async () => {
-			expect(hasLintWarnings(message, false)).toBe(true)
-		})
-	})
-
-	describe("'Pattern'", async () => {
-		test("nested", async () => {
-			expect(hasLintWarnings(pattern, true)).toBe(true)
-		})
-
-		test("not nested", async () => {
-			expect(hasLintWarnings(pattern, false)).toBe(true)
-		})
-	})
-
-	test("should throw an error if node type does not get handled", async () => {
-		expect(() => hasLintWarnings({ type: "unknown" } as unknown as LintableNode)).toThrow()
-	})
-})
-
-describe("hasLintReportsWithId", async () => {
-	describe("'Resource'", async () => {
-		test("nested", async () => {
-			expect(hasLintReportsWithId("id.4", resource, true)).toBe(true)
-		})
-
-		test("not nested", async () => {
-			expect(hasLintReportsWithId("id.4", resource, false)).toBe(true)
-		})
-	})
-
-	describe("'Message'", async () => {
-		test("nested", async () => {
-			expect(hasLintReportsWithId("id.4", message, true)).toBe(true)
-		})
-
-		test("not nested", async () => {
-			expect(hasLintReportsWithId("id.4", message, false)).toBe(true)
-		})
-	})
-
-	describe("'Pattern'", async () => {
-		test("nested", async () => {
-			expect(hasLintReportsWithId("id.4", pattern, true)).toBe(true)
-		})
-
-		test("not nested", async () => {
-			expect(hasLintReportsWithId("id.4", pattern, false)).toBe(true)
-		})
-	})
-
-	test("should throw an error if node type does not get handled", async () => {
-		expect(() =>
-			hasLintReportsWithId("id.1", {
-				type: "unknown",
-			} as unknown as LintableNode),
-		).toThrow()
-	})
-})
-
-describe("hasLintErrorsWithId", async () => {
-	describe("'Resource'", async () => {
-		test("nested", async () => {
-			expect(hasLintErrorsWithId("id.1", resource2, true)).toBe(false)
-		})
-
-		test("not nested", async () => {
-			expect(hasLintErrorsWithId("id.1", resource2, false)).toBe(false)
-		})
-	})
-
-	describe("'Message'", async () => {
-		test("nested", async () => {
-			expect(hasLintErrorsWithId("id.1", message, true)).toBe(true)
-		})
-
-		test("not nested", async () => {
-			expect(hasLintErrorsWithId("id.1", message, false)).toBe(false)
-		})
-	})
-
-	describe("'Pattern'", async () => {
-		test("nested", async () => {
-			expect(hasLintErrorsWithId("id.1", pattern, true)).toBe(true)
-		})
-
-		test("not nested", async () => {
-			expect(hasLintErrorsWithId("id.1", pattern, false)).toBe(true)
-		})
-	})
-
-	test("should throw an error if node type does not get handled", async () => {
-		expect(() =>
-			hasLintErrorsWithId("id.1", {
-				type: "unknown",
-			} as unknown as LintableNode),
-		).toThrow()
-	})
-})
-
-describe("hasLintWarningsWithId", async () => {
-	describe("'Resource'", async () => {
-		test("nested", async () => {
-			expect(hasLintWarningsWithId("id.1", resource, true)).toBe(true)
-		})
-
-		test("not nested", async () => {
-			expect(hasLintWarningsWithId("id.1", resource, false)).toBe(true)
-		})
-	})
-
-	describe("'Message'", async () => {
-		test("nested", async () => {
-			expect(hasLintWarningsWithId("id.1", message, true)).toBe(true)
-		})
-
-		test("not nested", async () => {
-			expect(hasLintWarningsWithId("id.1", message, false)).toBe(true)
-		})
-	})
-
-	describe("'Pattern'", async () => {
-		test("nested", async () => {
-			expect(hasLintWarningsWithId("id.1", pattern, true)).toBe(false)
-		})
-
-		test("not nested", async () => {
-			expect(hasLintWarningsWithId("id.1", pattern, false)).toBe(false)
-		})
-	})
-
-	test("should throw an error if node type does not get handled", async () => {
-		expect(() =>
-			hasLintWarningsWithId("id.1", {
-				type: "unknown",
-			} as unknown as LintableNode),
-		).toThrow()
-	})
+test("hasLintReports()", async () => {
+	expect(hasLintReports(resource)).toBe(true)
 })

--- a/source-code/core/src/lint/rule.ts
+++ b/source-code/core/src/lint/rule.ts
@@ -1,5 +1,5 @@
 import type { Message, Pattern, Resource } from "../ast/index.js"
-import type { Config, EnvironmentFunctions } from "../config/schema.js"
+import type { Config } from "../config/schema.js"
 import type { MaybePromise } from "../utilities/types.js"
 import { LintLevel, parseLintConfigArguments, Context } from "./context.js"
 
@@ -82,7 +82,6 @@ export type LintRule = {
 	level: false | LintLevel
 	setup: (
 		param: Pick<Config, "referenceLanguage" | "languages"> & {
-			env: EnvironmentFunctions
 			context: Context
 		},
 	) => MaybePromise<unknown>

--- a/source-code/core/src/lint/test-utilities.ts
+++ b/source-code/core/src/lint/test-utilities.ts
@@ -1,5 +1,4 @@
 import { lint as lintImplementation, LintRule } from "./index.js"
-import type { Config, EnvironmentFunctions } from "@inlang/core/config"
 import type { Message, Resource } from "@inlang/core/ast"
 import { vi } from "vitest"
 
@@ -27,23 +26,16 @@ const attachSpies = ({ visitors }: LintRule) => {
 	for (const key of ["Resource", "Message", "Pattern"] as const) attachSpiesToVisitor(visitors, key)
 }
 
-const env: EnvironmentFunctions = {
-	$fs: vi.fn() as any,
-	$import: vi.fn(),
-}
-
 export const lint = (rule: LintRule, resources: Resource[]) => {
 	attachSpies(rule)
 
 	const config = {
 		referenceLanguage: resources[0]?.languageTag.name,
 		languages: resources.map((resource) => resource.languageTag.name),
-		readResources: async () => resources,
-		writeResources: async () => undefined,
 		lint: { rules: [rule] },
-	} satisfies Config
+	}
 
-	return lintImplementation(config, env)
+	return lintImplementation({ config, resources })
 }
 
 export const createResource = (language: string, ...messages: Message[]) =>

--- a/source-code/website/src/pages/index/repositories.ts
+++ b/source-code/website/src/pages/index/repositories.ts
@@ -28,7 +28,8 @@ export const repositories: Repositories = [
 	{
 		owner: "knadh",
 		repository: "listmonk",
-		description: "High performance, self-hosted, newsletter and mailing list manager with a modern dashboard. Single binary app.",
+		description:
+			"High performance, self-hosted, newsletter and mailing list manager with a modern dashboard. Single binary app.",
 	},
 ]
 


### PR DESCRIPTION
## Problem

I went through the source code of lint and found numerous things we should likely change. I am to blame as I reviewed and accepted the PR that introduced the issues beneath. 

1. Linting depends on the entire inlang config even though only `languages`, `referenceLanguage`, and `lint` is used. 
2. Linting depends on the `env` and makes `readResources` calls under the hood.  
3. Arguments of functions do not use the object pattern, making public API changes difficult.
4. The surface area, especially of query, seems too large. 

## Proposal

### 1. Only use the bare minimum of the config schema 

All modules in core are supposed to be used individually as much as possible. By forcing the existence of config properties that are unused like `writeResources`, the goal is contradicted. Furthermore, testing becomes easier because redundant properties do not need to be mocked. 

```ts
// current
export const lint = async (config: Config, env: EnvironmentFunctions )

// proposal
export const lint = async (
  config: Pick<Config, "lint" | "languages" | "referenceLanguage">, 
  resources: ast.Resource[], 
  env: EnvironmentFunctions 
)
```

### 2. Remove the environment function from lint

- Exposing the environment functions increases the complexity of lint by a wide margin. A lint rule should not depend on the file system or dynamically importing JavaScript. If the latter use case emerges, we can introduce environment functions again. 
- Testing complexity increases because the env needs to be passed around. 
- No tests and rules in standard-lint-rules use environment functions.  

```ts
// current
export const lint = async (config: Config, env: EnvironmentFunctions )

// proposal
export const lint = async (
  config: Pick<Config, "lint" | "languages" | "referenceLanguage">, 
  resources: ast.Resource[], 
)
```

### 3. Use the object argument pattern for public-facing APIs

Introducing changes like 1 and 2 becomes non-breaking if the "object argument pattern" is used. The order of the arguments becomes irrelevant. Yes, function overloads could be used but using objects as arguments is superior. No type unions need to be created, old arguments can be soft deprecated, ultimately leading to a better DX and maintainability on our side.  

```ts
// current
export const lint = async (config: Config, env: EnvironmentFunctions )

// proposal
export const lint = async (args: {
  config: Pick<Config, "lint" | "languages" | "referenceLanguage">, 
  resources: ast.Resource[], 
})
```

### 4. Remove redundant query functions

The surface area of the query functions is huge. Mainly driven by separating the type `error` and `warning` into dedicated functions. The benefit seems to be non-existent. 

- The quantity of function is overwhelming from a DX perspective. 
- The quantity of functions leads to maintenance overhead with close to no benefit.
- For example, the `getLintReportsByLevel("warning")` function serves the same functionality as `getLintWarnings()`. 
- Introducing a custom query function for each level has a "big O notation" of n+3.  

Current APIs 

```ts
getLintReports()
getLintReportsByLevel()
getLintErrors() [redundant]
getLintWarnings() [redundant]
getLintReportsWithId() 
getLintErrorsWithId() [redundant]
getLintWarningsWithId() [redundant]
hasLintReports()
hasLintErrors() [redundant]
hasLintWarnings() [redundant]
hasLintReportsWithId()
hasLintErrorsWithId() [redundant]
hasLintWarningsWithId() [redundant]
```

Proposal a) introduce a type field to all functions

```ts
getLintReports(node, ..., level)
getLintReportsByLevel()
getLintReportsWithId() 
hasLintReports()
hasLintReportsWithId()
```

Proposal b) use the object argument pattern to expose "query arguments" to each function. The API would be severely simplified by only exposing two functions. 

PS a good showcase of why the object argument pattern is superior to positional arguments. 

```ts
getLintReports(node, { level, id, nested } )
hasLintReports(node, { level, id, nested } )
```
