### PR TITLE
Do shallow clone 

### DIFF
--- a/source-code/website/src/pages/editor/@host/@owner/@repository/State.tsx
+++ b/source-code/website/src/pages/editor/@host/@owner/@repository/State.tsx
@@ -478,7 +478,7 @@ async function cloneRepository(args: {
 		depth: 1,
 	})
 
-	// fetch the remaining 100 commits from the branch
+	// fetch 100 more commits, can get more commits if needed
 	// https://isomorphic-git.org/docs/en/faq#how-to-make-a-shallow-repository-unshallow
 	raw.fetch({
 		fs: args.fs,

--- a/source-code/website/src/pages/editor/@host/@owner/@repository/State.tsx
+++ b/source-code/website/src/pages/editor/@host/@owner/@repository/State.tsx
@@ -466,14 +466,30 @@ async function cloneRepository(args: {
 	if (host === undefined || owner === undefined || repository === undefined) {
 		return undefined
 	}
+
+	// do shallow clone, get first commit and just one branch
 	await raw.clone({
 		fs: args.fs,
 		http,
 		dir: "/",
 		corsProxy: clientSideEnv.VITE_GIT_REQUEST_PROXY_PATH,
 		url: `https://${host}/${owner}/${repository}`,
+		singleBranch: true,
 		depth: 1,
 	})
+
+	// fetch the remaining 100 commits from the branch
+	// https://isomorphic-git.org/docs/en/faq#how-to-make-a-shallow-repository-unshallow
+	raw.fetch({
+		fs: args.fs,
+		http,
+		dir: "/",
+		corsProxy: clientSideEnv.VITE_GIT_REQUEST_PROXY_PATH,
+		url: `https://${host}/${owner}/${repository}`,
+		depth: 100,
+		relative: true,
+	})
+
 	// triggering a side effect here to trigger a re-render
 	// of components that depends on fs
 	const date = new Date()

--- a/source-code/website/src/pages/editor/@host/@owner/@repository/State.tsx
+++ b/source-code/website/src/pages/editor/@host/@owner/@repository/State.tsx
@@ -472,6 +472,7 @@ async function cloneRepository(args: {
 		dir: "/",
 		corsProxy: clientSideEnv.VITE_GIT_REQUEST_PROXY_PATH,
 		url: `https://${host}/${owner}/${repository}`,
+		depth: 1,
 	})
 	// triggering a side effect here to trigger a re-render
 	// of components that depends on fs

--- a/source-code/website/src/pages/index/repositories.ts
+++ b/source-code/website/src/pages/index/repositories.ts
@@ -28,7 +28,8 @@ export const repositories: Repositories = [
 	{
 		owner: "knadh",
 		repository: "listmonk",
-		description: "High performance, self-hosted, newsletter and mailing list manager with a modern dashboard. Single binary app.",
+		description:
+			"High performance, self-hosted, newsletter and mailing list manager with a modern dashboard. Single binary app.",
 	},
 ]
 


### PR DESCRIPTION
Following docs from [here](https://isomorphic-git.org/docs/en/faq#how-to-make-a-shallow-repository-unshallow). 

This should do a shallow clone then fetch the remaining history.

I just tested it on recently added https://github.com/knadh/listmonk and it speed up showing translations 4-5x.

I wanted to test remaining features like commit/push too but got issues on localhost when trying to auth with GitHub.

