### PR TITLE
fix: linting errors

### DIFF
--- a/.changeset/twenty-mayflies-report.md
+++ b/.changeset/twenty-mayflies-report.md
@@ -1,0 +1,5 @@
+---
+"@inlang/website": patch
+---
+
+Fixes linting errors

--- a/package-lock.json
+++ b/package-lock.json
@@ -13735,7 +13735,9 @@
 				"fsevents": "~2.3.2"
 			}
 		},
-		"source-code/sdk-js": {},
+		"source-code/sdk-js": {
+			"name": "@inlang/sdk-js"
+		},
 		"source-code/utilities": {
 			"name": "@inlang/utilities",
 			"extraneous": true

--- a/source-code/website/src/pages/editor/@host/@owner/@repository/components/NotificationHint.tsx
+++ b/source-code/website/src/pages/editor/@host/@owner/@repository/components/NotificationHint.tsx
@@ -1,5 +1,5 @@
 import type { Accessor } from "solid-js"
-import { createSignal, For, Show } from "solid-js"
+import { createSignal, For } from "solid-js"
 
 type NotificationType = "info" | "warning" | "error"
 
@@ -15,6 +15,7 @@ interface NotificationHintProps {
 
 export const NotificationHint = (props: NotificationHintProps) => {
 	const [open, setOpen] = createSignal(false)
+	// eslint-disable-next-line solid/reactivity
 	const dominantType: NotificationType = getDominantType(props.notifications)
 
 	return (

--- a/source-code/website/src/pages/editor/@host/@owner/@repository/components/PatternEditor.tsx
+++ b/source-code/website/src/pages/editor/@host/@owner/@repository/components/PatternEditor.tsx
@@ -7,11 +7,9 @@ import { analytics } from "@src/services/analytics/index.js"
 import { query } from "@inlang/core/query"
 import { showToast } from "@src/components/Toast.jsx"
 import { clickOutside } from "@src/directives/clickOutside.js"
-import { InlineNotification } from "@src/components/notification/InlineNotification.jsx"
 import MaterialSymbolsCommitRounded from "~icons/material-symbols/commit-rounded"
 import MaterialSymbolsTranslateRounded from "~icons/material-symbols/translate-rounded"
 import { onMachineTranslate } from "./PatternEditor.telefunc.js"
-import { Shortcut } from "./Shortcut.jsx"
 import { Notification, NotificationHint } from "./NotificationHint.jsx"
 
 /**
@@ -24,10 +22,12 @@ export function PatternEditor(props: {
 	referenceMessage?: ast.Message
 	message: ast.Message | undefined
 }) {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const [localStorage, setLocalStorage] = useLocalStorage()
 	const { resources, setResources, referenceResource, userIsCollaborator, routeParams } =
 		useEditorState()
 
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const [showMachineLearningWarningDialog, setShowMachineLearningWarningDialog] =
 		createSignal(false)
 

--- a/source-code/website/src/pages/editor/@host/@owner/@repository/components/Shortcut.tsx
+++ b/source-code/website/src/pages/editor/@host/@owner/@repository/components/Shortcut.tsx
@@ -32,6 +32,7 @@ const getShortcutStyling = (color: "primary" | "default") => {
 }
 
 const formatCodes = (codes: Array<KeyboardEvent["code"]>) => {
+	// eslint-disable-next-line solid/reactivity
 	return codes.map((code) => {
 		switch (code) {
 			case "ControlLeft" || "ControlRight":

--- a/source-code/website/src/pages/editor/@host/@owner/@repository/index.page.tsx
+++ b/source-code/website/src/pages/editor/@host/@owner/@repository/index.page.tsx
@@ -7,7 +7,6 @@ import MaterialSymbolsUnknownDocumentOutlineRounded from "~icons/material-symbol
 import MaterialSymbolsArrowOutwardRounded from "~icons/material-symbols/arrow-outward-rounded"
 import { Meta, Title } from "@solidjs/meta"
 import { EditorStateProvider, useEditorState } from "./State.jsx"
-import { PreviewMessageFeatures } from "./components/PreviewMessageFeatures.jsx"
 
 export function Page() {
 	return (

--- a/source-code/website/src/pages/index/index.page.tsx
+++ b/source-code/website/src/pages/index/index.page.tsx
@@ -1,12 +1,10 @@
 import { LandingPageLayout as RootLayout } from "../Layout.jsx"
-import styles from "./github-markdown.module.css"
 import { Meta, Title } from "@solidjs/meta"
 import Hero from "./sections/01-hero/index.jsx"
 import Credibility from "./sections/02-credibility/index.jsx"
 import Editor from "./sections/03-editor/index.jsx"
 import VsCodeExtension from "./sections/04-vscodExtension/index.jsx"
 import Cli from "./sections/05-cli/index.jsx"
-import GetStarted from "./sections/06-getStarted/index.jsx"
 
 export type PageProps = {
 	markdown: string

--- a/source-code/website/src/pages/index/sections/05-cli/index.tsx
+++ b/source-code/website/src/pages/index/sections/05-cli/index.tsx
@@ -1,5 +1,4 @@
 import { createSignal, Show } from "solid-js"
-import { Button } from "../../components/Button.jsx"
 import { FeatureGitTitle } from "../../components/FeatureGitTitle.jsx"
 import { SectionLayout } from "../../components/sectionLayout.jsx"
 import cliImage from "./../../assets/cli-image.png"
@@ -21,6 +20,7 @@ const data = {
 
 const Cli = () => {
 	// toggle between validate and extract
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const [cliSlider, setCliSlider] = createSignal("validate")
 
 	return (


### PR DESCRIPTION
As I've been looking at some of the PRs with the project, I've noticed some linting errors being shown. This PR cleans them, although with some `// eslint-disable` magic, due to not being completely sure if some of the destructuring in Solid might brake. I'm open to suggestions on how this could be dealt more appropriately 