### PR TITLE
build config utility function for plugins 

### DIFF
--- a/documentation/plugins.md
+++ b/documentation/plugins.md
@@ -22,10 +22,9 @@ Plugins can be imported via the `$import` [environment function](/documentation/
 // inlang.config.js
 
 export async function defineConfig(env) {
-  const plugin = await env.$import
-
-    "https://cdn.jsdelivr.net/gh/samuelstroschein/inlang-plugin-json/dist/index.js"
-  );
+	const plugin = await env.$import(
+		"https://cdn.jsdelivr.net/gh/samuelstroschein/inlang-plugin-json/dist/index.js",
+	)
 }
 ```
 
@@ -53,11 +52,9 @@ export async function defineConfig(env) {
 ## Writing plugins
 
 Read on how to write plugins in the [plugin template repository](https://github.com/inlang/plugin-template).
+
 {% Figure
-
-src="https://user-images.githubusercontent.com/72493222/214296359-1ddd2fdb-03f3-4993-a493-9b1a353c4b88.png"
-
-alt="visualisation of the inlang AST/object"
-
-caption="Visualisation of the inlang AST/object"
+  src="https://user-images.githubusercontent.com/72493222/214296359-1ddd2fdb-03f3-4993-a493-9b1a353c4b88.png"
+  alt="visualisation of the inlang AST/object"
+  caption="Visualisation of the inlang AST/object"
 /%}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1252,6 +1252,29 @@
 				"get-tsconfig": "^4.2.0"
 			}
 		},
+		"node_modules/@esbuild-plugins/node-modules-polyfill": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
+			"integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
+			"dependencies": {
+				"escape-string-regexp": "^4.0.0",
+				"rollup-plugin-node-polyfills": "^0.2.1"
+			},
+			"peerDependencies": {
+				"esbuild": "*"
+			}
+		},
+		"node_modules/@esbuild-plugins/node-modules-polyfill/node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/@esbuild/android-arm": {
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.16.tgz",
@@ -1259,7 +1282,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"android"
@@ -1275,7 +1297,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"android"
@@ -1291,7 +1312,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"android"
@@ -1307,7 +1327,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"darwin"
@@ -1323,7 +1342,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"darwin"
@@ -1339,7 +1357,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"freebsd"
@@ -1355,7 +1372,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"freebsd"
@@ -1371,7 +1387,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -1387,7 +1402,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -1403,7 +1417,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -1419,7 +1432,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -1435,7 +1447,6 @@
 			"cpu": [
 				"mips64el"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -1451,7 +1462,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -1467,7 +1477,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -1483,7 +1492,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -1499,7 +1507,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -1515,7 +1522,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"netbsd"
@@ -1531,7 +1537,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"openbsd"
@@ -1547,7 +1552,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"sunos"
@@ -1563,7 +1567,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"win32"
@@ -1579,7 +1582,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"win32"
@@ -1595,7 +1597,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"win32"
@@ -6313,7 +6314,6 @@
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.16.tgz",
 			"integrity": "sha512-o6iS9zxdHrrojjlj6pNGC2NAg86ECZqIETswTM5KmJitq+R1YmahhWtMumeQp9lHqJaROGnsBi2RLawGnfo5ZQ==",
-			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
@@ -6353,7 +6353,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"android"
@@ -6369,7 +6368,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"android"
@@ -6385,7 +6383,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"darwin"
@@ -6401,7 +6398,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"darwin"
@@ -6417,7 +6413,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"freebsd"
@@ -6433,7 +6428,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"freebsd"
@@ -6449,7 +6443,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -6465,7 +6458,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -6481,7 +6473,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -6497,7 +6488,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -6513,7 +6503,6 @@
 			"cpu": [
 				"mips64el"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -6529,7 +6518,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -6545,7 +6533,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -6561,7 +6548,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -6577,7 +6563,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"netbsd"
@@ -6593,7 +6578,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"openbsd"
@@ -6609,7 +6593,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"sunos"
@@ -6625,7 +6608,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"win32"
@@ -6641,7 +6623,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"win32"
@@ -6657,7 +6638,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"win32"
@@ -9496,7 +9476,6 @@
 			"version": "0.25.9",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
 			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-			"dev": true,
 			"dependencies": {
 				"sourcemap-codec": "^1.4.8"
 			}
@@ -11513,7 +11492,6 @@
 			"resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
 			"integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
 			"deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
-			"dev": true,
 			"dependencies": {
 				"estree-walker": "^0.6.1",
 				"magic-string": "^0.25.3",
@@ -11523,14 +11501,12 @@
 		"node_modules/rollup-plugin-inject/node_modules/estree-walker": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-			"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-			"dev": true
+			"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="
 		},
 		"node_modules/rollup-plugin-node-polyfills": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
 			"integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
-			"dev": true,
 			"dependencies": {
 				"rollup-plugin-inject": "^3.0.0"
 			}
@@ -11539,7 +11515,6 @@
 			"version": "2.8.2",
 			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
 			"integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
-			"dev": true,
 			"dependencies": {
 				"estree-walker": "^0.6.1"
 			}
@@ -11547,8 +11522,7 @@
 		"node_modules/rollup-pluginutils/node_modules/estree-walker": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-			"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-			"dev": true
+			"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="
 		},
 		"node_modules/rrweb-snapshot": {
 			"version": "1.1.14",
@@ -12128,8 +12102,7 @@
 		"node_modules/sourcemap-codec": {
 			"version": "1.4.8",
 			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-			"dev": true
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
 		},
 		"node_modules/spawn-command": {
 			"version": "0.0.2-1",
@@ -14166,6 +14139,8 @@
 			"name": "@inlang/core",
 			"version": "0.5.0",
 			"dependencies": {
+				"@esbuild-plugins/node-modules-polyfill": "^0.2.2",
+				"dedent": "^0.7.0",
 				"zod": "^3.21.4"
 			},
 			"devDependencies": {
@@ -14174,6 +14149,78 @@
 			},
 			"engines": {
 				"node": ">=16.15.0"
+			},
+			"peerDependencies": {
+				"esbuild": "^0.17.14"
+			}
+		},
+		"source-code/core/node_modules/@esbuild/android-arm": {
+			"version": "0.17.14",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.14.tgz",
+			"integrity": "sha512-0CnlwnjDU8cks0yJLXfkaU/uoLyRf9VZJs4p1PskBr2AlAHeEsFEwJEo0of/Z3g+ilw5mpyDwThlxzNEIxOE4g==",
+			"cpu": [
+				"arm"
+			],
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"source-code/core/node_modules/@esbuild/linux-loong64": {
+			"version": "0.17.14",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.14.tgz",
+			"integrity": "sha512-vp15H+5NR6hubNgMluqqKza85HcGJgq7t6rMH7O3Y6ApiOWPkvW2AJfNojUQimfTp6OUrACUXfR4hmpcENXoMQ==",
+			"cpu": [
+				"loong64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"source-code/core/node_modules/esbuild": {
+			"version": "0.17.14",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.14.tgz",
+			"integrity": "sha512-vOO5XhmVj/1XQR9NQ1UPq6qvMYL7QFJU57J5fKBKBKxp17uDt5PgxFDb4A2nEiXhr1qQs4x0F5+66hVVw4ruNw==",
+			"hasInstallScript": true,
+			"peer": true,
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"optionalDependencies": {
+				"@esbuild/android-arm": "0.17.14",
+				"@esbuild/android-arm64": "0.17.14",
+				"@esbuild/android-x64": "0.17.14",
+				"@esbuild/darwin-arm64": "0.17.14",
+				"@esbuild/darwin-x64": "0.17.14",
+				"@esbuild/freebsd-arm64": "0.17.14",
+				"@esbuild/freebsd-x64": "0.17.14",
+				"@esbuild/linux-arm": "0.17.14",
+				"@esbuild/linux-arm64": "0.17.14",
+				"@esbuild/linux-ia32": "0.17.14",
+				"@esbuild/linux-loong64": "0.17.14",
+				"@esbuild/linux-mips64el": "0.17.14",
+				"@esbuild/linux-ppc64": "0.17.14",
+				"@esbuild/linux-riscv64": "0.17.14",
+				"@esbuild/linux-s390x": "0.17.14",
+				"@esbuild/linux-x64": "0.17.14",
+				"@esbuild/netbsd-x64": "0.17.14",
+				"@esbuild/openbsd-x64": "0.17.14",
+				"@esbuild/sunos-x64": "0.17.14",
+				"@esbuild/win32-arm64": "0.17.14",
+				"@esbuild/win32-ia32": "0.17.14",
+				"@esbuild/win32-x64": "0.17.14"
 			}
 		},
 		"source-code/cors-proxy": {
@@ -15375,158 +15422,152 @@
 				"get-tsconfig": "^4.2.0"
 			}
 		},
+		"@esbuild-plugins/node-modules-polyfill": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
+			"integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
+			"requires": {
+				"escape-string-regexp": "^4.0.0",
+				"rollup-plugin-node-polyfills": "^0.2.1"
+			},
+			"dependencies": {
+				"escape-string-regexp": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+				}
+			}
+		},
 		"@esbuild/android-arm": {
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.16.tgz",
 			"integrity": "sha512-nyB6CH++2mSgx3GbnrJsZSxzne5K0HMyNIWafDHqYy7IwxFc4fd/CgHVZXr8Eh+Q3KbIAcAe3vGyqIPhGblvMQ==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/android-arm64": {
 			"version": "0.17.14",
 			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.14.tgz",
 			"integrity": "sha512-eLOpPO1RvtsP71afiFTvS7tVFShJBCT0txiv/xjFBo5a7R7Gjw7X0IgIaFoLKhqXYAXhahoXm7qAmRXhY4guJg==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/android-x64": {
 			"version": "0.17.14",
 			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.14.tgz",
 			"integrity": "sha512-nrfQYWBfLGfSGLvRVlt6xi63B5IbfHm3tZCdu/82zuFPQ7zez4XjmRtF/wIRYbJQ/DsZrxJdEvYFE67avYXyng==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/darwin-arm64": {
 			"version": "0.17.14",
 			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.14.tgz",
 			"integrity": "sha512-eoSjEuDsU1ROwgBH/c+fZzuSyJUVXQTOIN9xuLs9dE/9HbV/A5IqdXHU1p2OfIMwBwOYJ9SFVGGldxeRCUJFyw==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/darwin-x64": {
 			"version": "0.17.14",
 			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.14.tgz",
 			"integrity": "sha512-zN0U8RWfrDttdFNkHqFYZtOH8hdi22z0pFm0aIJPsNC4QQZv7je8DWCX5iA4Zx6tRhS0CCc0XC2m7wKsbWEo5g==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/freebsd-arm64": {
 			"version": "0.17.14",
 			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.14.tgz",
 			"integrity": "sha512-z0VcD4ibeZWVQCW1O7szaLxGsx54gcCnajEJMdYoYjLiq4g1jrP2lMq6pk71dbS5+7op/L2Aod+erw+EUr28/A==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/freebsd-x64": {
 			"version": "0.17.14",
 			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.14.tgz",
 			"integrity": "sha512-hd9mPcxfTgJlolrPlcXkQk9BMwNBvNBsVaUe5eNUqXut6weDQH8whcNaKNF2RO8NbpT6GY8rHOK2A9y++s+ehw==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-arm": {
 			"version": "0.17.14",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.14.tgz",
 			"integrity": "sha512-BNTl+wSJ1omsH8s3TkQmIIIQHwvwJrU9u1ggb9XU2KTVM4TmthRIVyxSp2qxROJHhZuW/r8fht46/QE8hU8Qvg==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-arm64": {
 			"version": "0.17.14",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.14.tgz",
 			"integrity": "sha512-FhAMNYOq3Iblcj9i+K0l1Fp/MHt+zBeRu/Qkf0LtrcFu3T45jcwB6A1iMsemQ42vR3GBhjNZJZTaCe3VFPbn9g==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-ia32": {
 			"version": "0.17.14",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.14.tgz",
 			"integrity": "sha512-91OK/lQ5y2v7AsmnFT+0EyxdPTNhov3y2CWMdizyMfxSxRqHazXdzgBKtlmkU2KYIc+9ZK3Vwp2KyXogEATYxQ==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-loong64": {
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.16.tgz",
 			"integrity": "sha512-SDLfP1uoB0HZ14CdVYgagllgrG7Mdxhkt4jDJOKl/MldKrkQ6vDJMZKl2+5XsEY/Lzz37fjgLQoJBGuAw/x8kQ==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-mips64el": {
 			"version": "0.17.14",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.14.tgz",
 			"integrity": "sha512-90TOdFV7N+fgi6c2+GO9ochEkmm9kBAKnuD5e08GQMgMINOdOFHuYLPQ91RYVrnWwQ5683sJKuLi9l4SsbJ7Hg==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-ppc64": {
 			"version": "0.17.14",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.14.tgz",
 			"integrity": "sha512-NnBGeoqKkTugpBOBZZoktQQ1Yqb7aHKmHxsw43NddPB2YWLAlpb7THZIzsRsTr0Xw3nqiPxbA1H31ZMOG+VVPQ==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-riscv64": {
 			"version": "0.17.14",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.14.tgz",
 			"integrity": "sha512-0qdlKScLXA8MGVy21JUKvMzCYWovctuP8KKqhtE5A6IVPq4onxXhSuhwDd2g5sRCzNDlDjitc5sX31BzDoL5Fw==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-s390x": {
 			"version": "0.17.14",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.14.tgz",
 			"integrity": "sha512-Hdm2Jo1yaaOro4v3+6/zJk6ygCqIZuSDJHdHaf8nVH/tfOuoEX5Riv03Ka15LmQBYJObUTNS1UdyoMk0WUn9Ww==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-x64": {
 			"version": "0.17.14",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.14.tgz",
 			"integrity": "sha512-8KHF17OstlK4DuzeF/KmSgzrTWQrkWj5boluiiq7kvJCiQVzUrmSkaBvcLB2UgHpKENO2i6BthPkmUhNDaJsVw==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/netbsd-x64": {
 			"version": "0.17.14",
 			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.14.tgz",
 			"integrity": "sha512-nVwpqvb3yyXztxIT2+VsxJhB5GCgzPdk1n0HHSnchRAcxqKO6ghXwHhJnr0j/B+5FSyEqSxF4q03rbA2fKXtUQ==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/openbsd-x64": {
 			"version": "0.17.14",
 			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.14.tgz",
 			"integrity": "sha512-1RZ7uQQ9zcy/GSAJL1xPdN7NDdOOtNEGiJalg/MOzeakZeTrgH/DoCkbq7TaPDiPhWqnDF+4bnydxRqQD7il6g==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/sunos-x64": {
 			"version": "0.17.14",
 			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.14.tgz",
 			"integrity": "sha512-nqMjDsFwv7vp7msrwWRysnM38Sd44PKmW8EzV01YzDBTcTWUpczQg6mGao9VLicXSgW/iookNK6AxeogNVNDZA==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/win32-arm64": {
 			"version": "0.17.14",
 			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.14.tgz",
 			"integrity": "sha512-xrD0mccTKRBBIotrITV7WVQAwNJ5+1va6L0H9zN92v2yEdjfAN7864cUaZwJS7JPEs53bDTzKFbfqVlG2HhyKQ==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/win32-ia32": {
 			"version": "0.17.14",
 			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.14.tgz",
 			"integrity": "sha512-nXpkz9bbJrLLyUTYtRotSS3t5b+FOuljg8LgLdINWFs3FfqZMtbnBCZFUmBzQPyxqU87F8Av+3Nco/M3hEcu1w==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/win32-x64": {
 			"version": "0.17.14",
 			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.14.tgz",
 			"integrity": "sha512-gPQmsi2DKTaEgG14hc3CHXHp62k8g6qr0Pas+I4lUxRMugGSATh/Bi8Dgusoz9IQ0IfdrvLpco6kujEIBoaogA==",
-			"dev": true,
 			"optional": true
 		},
 		"@eslint-community/eslint-utils": {
@@ -15734,9 +15775,57 @@
 		"@inlang/core": {
 			"version": "file:source-code/core",
 			"requires": {
+				"@esbuild-plugins/node-modules-polyfill": "^0.2.2",
+				"dedent": "*",
 				"memfs": "^3.4.13",
 				"tsd": "^0.25.0",
 				"zod": "^3.21.4"
+			},
+			"dependencies": {
+				"@esbuild/android-arm": {
+					"version": "0.17.14",
+					"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.14.tgz",
+					"integrity": "sha512-0CnlwnjDU8cks0yJLXfkaU/uoLyRf9VZJs4p1PskBr2AlAHeEsFEwJEo0of/Z3g+ilw5mpyDwThlxzNEIxOE4g==",
+					"optional": true,
+					"peer": true
+				},
+				"@esbuild/linux-loong64": {
+					"version": "0.17.14",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.14.tgz",
+					"integrity": "sha512-vp15H+5NR6hubNgMluqqKza85HcGJgq7t6rMH7O3Y6ApiOWPkvW2AJfNojUQimfTp6OUrACUXfR4hmpcENXoMQ==",
+					"optional": true,
+					"peer": true
+				},
+				"esbuild": {
+					"version": "0.17.14",
+					"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.14.tgz",
+					"integrity": "sha512-vOO5XhmVj/1XQR9NQ1UPq6qvMYL7QFJU57J5fKBKBKxp17uDt5PgxFDb4A2nEiXhr1qQs4x0F5+66hVVw4ruNw==",
+					"peer": true,
+					"requires": {
+						"@esbuild/android-arm": "0.17.14",
+						"@esbuild/android-arm64": "0.17.14",
+						"@esbuild/android-x64": "0.17.14",
+						"@esbuild/darwin-arm64": "0.17.14",
+						"@esbuild/darwin-x64": "0.17.14",
+						"@esbuild/freebsd-arm64": "0.17.14",
+						"@esbuild/freebsd-x64": "0.17.14",
+						"@esbuild/linux-arm": "0.17.14",
+						"@esbuild/linux-arm64": "0.17.14",
+						"@esbuild/linux-ia32": "0.17.14",
+						"@esbuild/linux-loong64": "0.17.14",
+						"@esbuild/linux-mips64el": "0.17.14",
+						"@esbuild/linux-ppc64": "0.17.14",
+						"@esbuild/linux-riscv64": "0.17.14",
+						"@esbuild/linux-s390x": "0.17.14",
+						"@esbuild/linux-x64": "0.17.14",
+						"@esbuild/netbsd-x64": "0.17.14",
+						"@esbuild/openbsd-x64": "0.17.14",
+						"@esbuild/sunos-x64": "0.17.14",
+						"@esbuild/win32-arm64": "0.17.14",
+						"@esbuild/win32-ia32": "0.17.14",
+						"@esbuild/win32-x64": "0.17.14"
+					}
+				}
 			}
 		},
 		"@inlang/design-system": {
@@ -19353,7 +19442,6 @@
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.16.tgz",
 			"integrity": "sha512-o6iS9zxdHrrojjlj6pNGC2NAg86ECZqIETswTM5KmJitq+R1YmahhWtMumeQp9lHqJaROGnsBi2RLawGnfo5ZQ==",
-			"dev": true,
 			"requires": {
 				"@esbuild/android-arm": "0.15.16",
 				"@esbuild/linux-loong64": "0.15.16",
@@ -19383,140 +19471,120 @@
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.16.tgz",
 			"integrity": "sha512-Vwkv/sT0zMSgPSVO3Jlt1pUbnZuOgtOQJkJkyyJFAlLe7BiT8e9ESzo0zQSx4c3wW4T6kGChmKDPMbWTgtliQA==",
-			"dev": true,
 			"optional": true
 		},
 		"esbuild-android-arm64": {
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.16.tgz",
 			"integrity": "sha512-lqfKuofMExL5niNV3gnhMUYacSXfsvzTa/58sDlBET/hCOG99Zmeh+lz6kvdgvGOsImeo6J9SW21rFCogNPLxg==",
-			"dev": true,
 			"optional": true
 		},
 		"esbuild-darwin-64": {
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.16.tgz",
 			"integrity": "sha512-wo2VWk/n/9V2TmqUZ/KpzRjCEcr00n7yahEdmtzlrfQ3lfMCf3Wa+0sqHAbjk3C6CKkR3WKK/whkMq5Gj4Da9g==",
-			"dev": true,
 			"optional": true
 		},
 		"esbuild-darwin-arm64": {
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.16.tgz",
 			"integrity": "sha512-fMXaUr5ou0M4WnewBKsspMtX++C1yIa3nJ5R2LSbLCfJT3uFdcRoU/NZjoM4kOMKyOD9Sa/2vlgN8G07K3SJnw==",
-			"dev": true,
 			"optional": true
 		},
 		"esbuild-freebsd-64": {
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.16.tgz",
 			"integrity": "sha512-UzIc0xlRx5x9kRuMr+E3+hlSOxa/aRqfuMfiYBXu2jJ8Mzej4lGL7+o6F5hzhLqWfWm1GWHNakIdlqg1ayaTNQ==",
-			"dev": true,
 			"optional": true
 		},
 		"esbuild-freebsd-arm64": {
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.16.tgz",
 			"integrity": "sha512-8xyiYuGc0DLZphFQIiYaLHlfoP+hAN9RHbE+Ibh8EUcDNHAqbQgUrQg7pE7Bo00rXmQ5Ap6KFgcR0b4ALZls1g==",
-			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-32": {
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.16.tgz",
 			"integrity": "sha512-iGijUTV+0kIMyUVoynK0v+32Oi8yyp0xwMzX69GX+5+AniNy/C/AL1MjFTsozRp/3xQPl7jVux/PLe2ds10/2w==",
-			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-64": {
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.16.tgz",
 			"integrity": "sha512-tuSOjXdLw7VzaUj89fIdAaQT7zFGbKBcz4YxbWrOiXkwscYgE7HtTxUavreBbnRkGxKwr9iT/gmeJWNm4djy/g==",
-			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-arm": {
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.16.tgz",
 			"integrity": "sha512-XKcrxCEXDTOuoRj5l12tJnkvuxXBMKwEC5j0JISw3ziLf0j4zIwXbKbTmUrKFWbo6ZgvNpa7Y5dnbsjVvH39bQ==",
-			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-arm64": {
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.16.tgz",
 			"integrity": "sha512-mPYksnfHnemNrvjrDhZyixL/AfbJN0Xn9S34ZOHYdh6/jJcNd8iTsv3JwJoEvTJqjMggjMhGUPJAdjnFBHoH8A==",
-			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-mips64le": {
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.16.tgz",
 			"integrity": "sha512-kSJO2PXaxfm0pWY39+YX+QtpFqyyrcp0ZeI8QPTrcFVQoWEPiPVtOfTZeS3ZKedfH+Ga38c4DSzmKMQJocQv6A==",
-			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-ppc64le": {
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.16.tgz",
 			"integrity": "sha512-NimPikwkBY0yGABw6SlhKrtT35sU4O23xkhlrTT/O6lSxv3Pm5iSc6OYaqVAHWkLdVf31bF4UDVFO+D990WpAA==",
-			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-riscv64": {
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.16.tgz",
 			"integrity": "sha512-ty2YUHZlwFOwp7pR+J87M4CVrXJIf5ZZtU/umpxgVJBXvWjhziSLEQxvl30SYfUPq0nzeWKBGw5i/DieiHeKfw==",
-			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-s390x": {
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.16.tgz",
 			"integrity": "sha512-VkZaGssvPDQtx4fvVdZ9czezmyWyzpQhEbSNsHZZN0BHvxRLOYAQ7sjay8nMQwYswP6O2KlZluRMNPYefFRs+w==",
-			"dev": true,
 			"optional": true
 		},
 		"esbuild-netbsd-64": {
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.16.tgz",
 			"integrity": "sha512-ElQ9rhdY51et6MJTWrCPbqOd/YuPowD7Cxx3ee8wlmXQQVW7UvQI6nSprJ9uVFQISqSF5e5EWpwWqXZsECLvXg==",
-			"dev": true,
 			"optional": true
 		},
 		"esbuild-openbsd-64": {
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.16.tgz",
 			"integrity": "sha512-KgxMHyxMCT+NdLQE1zVJEsLSt2QQBAvJfmUGDmgEq8Fvjrf6vSKB00dVHUEDKcJwMID6CdgCpvYNt999tIYhqA==",
-			"dev": true,
 			"optional": true
 		},
 		"esbuild-sunos-64": {
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.16.tgz",
 			"integrity": "sha512-exSAx8Phj7QylXHlMfIyEfNrmqnLxFqLxdQF6MBHPdHAjT7fsKaX6XIJn+aQEFiOcE4X8e7VvdMCJ+WDZxjSRQ==",
-			"dev": true,
 			"optional": true
 		},
 		"esbuild-windows-32": {
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.16.tgz",
 			"integrity": "sha512-zQgWpY5pUCSTOwqKQ6/vOCJfRssTvxFuEkpB4f2VUGPBpdddZfdj8hbZuFRdZRPIVHvN7juGcpgCA/XCF37mAQ==",
-			"dev": true,
 			"optional": true
 		},
 		"esbuild-windows-64": {
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.16.tgz",
 			"integrity": "sha512-HjW1hHRLSncnM3MBCP7iquatHVJq9l0S2xxsHHj4yzf4nm9TU4Z7k4NkeMlD/dHQ4jPlQQhwcMvwbJiOefSuZw==",
-			"dev": true,
 			"optional": true
 		},
 		"esbuild-windows-arm64": {
 			"version": "0.15.16",
 			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.16.tgz",
 			"integrity": "sha512-oCcUKrJaMn04Vxy9Ekd8x23O8LoU01+4NOkQ2iBToKgnGj5eo1vU9i27NQZ9qC8NFZgnQQZg5oZWAejmbsppNA==",
-			"dev": true,
 			"optional": true
 		},
 		"escalade": {
@@ -21566,7 +21634,6 @@
 			"version": "0.25.9",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
 			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-			"dev": true,
 			"requires": {
 				"sourcemap-codec": "^1.4.8"
 			}
@@ -23036,7 +23103,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
 			"integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
-			"dev": true,
 			"requires": {
 				"estree-walker": "^0.6.1",
 				"magic-string": "^0.25.3",
@@ -23046,8 +23112,7 @@
 				"estree-walker": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-					"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-					"dev": true
+					"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="
 				}
 			}
 		},
@@ -23055,7 +23120,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
 			"integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
-			"dev": true,
 			"requires": {
 				"rollup-plugin-inject": "^3.0.0"
 			}
@@ -23064,7 +23128,6 @@
 			"version": "2.8.2",
 			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
 			"integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
-			"dev": true,
 			"requires": {
 				"estree-walker": "^0.6.1"
 			},
@@ -23072,8 +23135,7 @@
 				"estree-walker": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-					"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-					"dev": true
+					"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="
 				}
 			}
 		},
@@ -23513,8 +23575,7 @@
 		"sourcemap-codec": {
 			"version": "1.4.8",
 			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-			"dev": true
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
 		},
 		"spawn-command": {
 			"version": "0.0.2-1",

--- a/source-code/core/package.json
+++ b/source-code/core/package.json
@@ -52,10 +52,15 @@
 		"node": ">=16.15.0"
 	},
 	"dependencies": {
+		"@esbuild-plugins/node-modules-polyfill": "^0.2.2",
+		"dedent": "^0.7.0",
 		"zod": "^3.21.4"
 	},
 	"devDependencies": {
 		"memfs": "^3.4.13",
 		"tsd": "^0.25.0"
+	},
+	"peerDependencies": {
+		"esbuild": "^0.17.14"
 	}
 }

--- a/source-code/core/src/utilities/index.ts
+++ b/source-code/core/src/utilities/index.ts
@@ -1,1 +1,2 @@
 export { Result } from "./result.js"
+export { pluginBuildConfig } from "./pluginBuildConfig.js"

--- a/source-code/core/src/utilities/pluginBuildConfig.test.ts
+++ b/source-code/core/src/utilities/pluginBuildConfig.test.ts
@@ -1,0 +1,30 @@
+import { pluginBuildConfig } from "./pluginBuildConfig.js"
+import { it, expect } from "vitest"
+
+/**
+ * The tests concern validation of the pluginBuildConfig function.
+ *
+ * Testing every little property that is defined by the function like
+ * `bundle` or `platform` seems unnecessary.
+ */
+
+it("should throw an error if entrypoints is undefined", () => {
+	expect(() => pluginBuildConfig({})).toThrow()
+})
+
+it("should throw an error if entrypoints is not a single element", () => {
+	expect(() => pluginBuildConfig({ entryPoints: [] })).toThrow()
+	expect(() => pluginBuildConfig({ entryPoints: ["a", "b"] })).toThrow()
+})
+
+it("should not be possible to pass properties that the function defines itself", () => {
+	expect(() =>
+		pluginBuildConfig({
+			entryPoints: ["a"],
+			// @ts-expect-error
+			bundle: false,
+			platform: "browser",
+			format: "cjs",
+		}),
+	).toThrow()
+})

--- a/source-code/core/src/utilities/pluginBuildConfig.ts
+++ b/source-code/core/src/utilities/pluginBuildConfig.ts
@@ -1,0 +1,73 @@
+import type { BuildOptions } from "esbuild"
+import { NodeModulesPolyfillPlugin } from "@esbuild-plugins/node-modules-polyfill"
+import dedent from "dedent"
+
+/**
+ * These properties are defined by inlang and should not be overwritten by the user.
+ */
+const propertiesDefinedByInlang = ["bundle", "platform", "format", "target"] as const
+
+/**
+ * Use this function to configure the esbuild options for plugins.
+ *
+ * @example
+ *   import { build } from "esbuild"
+ *   import { pluginBuildConfig } from "@inlang/core/utilities"
+ *
+ *   await build(pluginBuildConfig({
+ *     // your build options
+ *   }))
+ */
+export function pluginBuildConfig(
+	options: Omit<BuildOptions, (typeof propertiesDefinedByInlang)[number]>,
+): BuildOptions {
+	// type casting. This is safe because we are only adding properties to the options object.
+	// furthermore, javascript uses references for objects. thus, no performance penalty.
+	const ops = options as BuildOptions
+
+	// ------------ VALIDATION ----------------
+
+	for (const property of propertiesDefinedByInlang) {
+		if (ops[property] !== undefined) {
+			throw Error(dedent`
+				The property \`${property}\` can not be defined.
+
+				Solution: Remove the property from your build options.
+
+				Context: The inlang build config defines this property 
+				and thereby ensures that your plugin is built in a way 
+				that is compatible with inlang.
+			`)
+		}
+	}
+
+	if (ops.entryPoints === undefined || ops.entryPoints.length !== 1) {
+		throw Error(dedent`
+			The entryPoints option must be defined and have exactly one entry.
+
+			Solution: Only define one entry point like \`["src/index.js"]\`
+
+			Context: Inlang expects plugins to be a single file that can be imported like
+			\`const plugin = await env.$import("https://example.com/plugin.js")\`.
+		`)
+	}
+
+	// ------------ STATIC OPTIONS ------------
+
+	ops.bundle = true
+	ops.platform = "neutral"
+	ops.format = "esm"
+	// es2020 in anticipation of sandboxing JS with QuickJS in the near future
+	ops.target = "es2020"
+
+	// ------------ PLUGINS -------------------
+	if (ops.plugins === undefined) {
+		ops.plugins = []
+	}
+	ops.plugins.push(
+		// @ts-ignore - for some reason we get a type error here
+		NodeModulesPolyfillPlugin(),
+	)
+
+	return ops
+}


### PR DESCRIPTION
Closes https://github.com/inlang/inlang/issues/430. 

I needed this for the standard lint rules repository. 

- [x] validation of the config with extensive error messages

### Decisions

#### 1. Only export a build config instead of an entire build pipeline

- Our goal of defining a build step for the user that is compatible with inlang and controlled by us is achieved.
- Plugin authors have different requirements/preferences. Defining the entire build chain will likely lead to frustrations "why doesn't this work" and problems on our side because we need to support edge cases. 
- (Defining an entire build pipeline would take much longer).

#### 2. Use esbuild instead of tsup

- tsup can't bundle/has a "wrong" definition of bundling https://github.com/egoist/tsup/issues/619
- developers can use tsup regardless because tsup expects an esbuild config (what we are exporting with this utility function)
- tsup is another abstraction layer that we would eventually need to fight (see the first point)
- code-splitting (a benefit of rollup) is not useful for plugins because they are bundled into one file anyways (for now)

#### 3. Don't care about typescript declaration FOR NOW

- We need to implement TypeScript HTTP type imports (or find another solution; I strongly believe TS type imports over HTTP is the correct one) as described https://github.com/inlang/inlang/discussions/431#discussioncomment-5221303 first. 
- Since we have control over the build config now, we should be able to add type declarations later. 