### PR TITLE
mock environment copy multiple directories option

### DIFF
--- a/.changeset/sharp-mayflies-hammer.md
+++ b/.changeset/sharp-mayflies-hammer.md
@@ -1,0 +1,5 @@
+---
+"@inlang/core": patch
+---
+
+add the option to copy multiple directories for a `mockEnvironment`

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
 		"format:fix": "turbo run format:fix && npm run format:fix:base .",
 		"---- OTHER ---------------------------------------------------------": "",
 		"clean": "npm run clean -ws && rm -f -r ./node_modules",
-		"changeset": "changeset",
 		"lint-staged": "lint-staged",
 		"prepare": "husky install"
 	},

--- a/source-code/core/src/test/mockEnvironment.test.ts
+++ b/source-code/core/src/test/mockEnvironment.test.ts
@@ -12,18 +12,32 @@ it("should copy a directory into the environment", async () => {
 	await fs.mkdir("./test/subdir", { recursive: true })
 	await fs.writeFile("./test/subdir/file.txt", "Hello World!")
 
-	const env = await mockEnvironment({ copyDirectory: { fs, path: "test" } })
+	const env = await mockEnvironment({ copyDirectory: { fs, paths: ["test"] } })
 	expect(await env.$fs.readFile("./test/file.txt", { encoding: "utf-8" })).toBe("Hello World!")
 	expect(await env.$fs.readFile("./test/subdir/file.txt", { encoding: "utf-8" })).toBe(
 		"Hello World!",
 	)
 })
 
+it("should copy multiple directories into the environment", async () => {
+	// to test with node (a real filesystem), outcomment this line and
+	// import fs from "node:fs/promises" above.
+	const fs = memfs.promises as EnvironmentFunctions["$fs"]
+	await fs.mkdir("./one", { recursive: true })
+	await fs.writeFile("./one/file.txt", "Hello from one")
+	await fs.mkdir("./two/subdir", { recursive: true })
+	await fs.writeFile("./two/file.txt", "Hello from two")
+
+	const env = await mockEnvironment({ copyDirectory: { fs, paths: ["one", "two"] } })
+	expect(await env.$fs.readFile("./one/file.txt", { encoding: "utf-8" })).toBe("Hello from one")
+	expect(await env.$fs.readFile("./two/file.txt", { encoding: "utf-8" })).toBe("Hello from two")
+})
+
 it("should be able to import JavaScript from the environment", async () => {
 	const fs = memfs.promises as EnvironmentFunctions["$fs"]
 	await fs.mkdir("./test", { recursive: true })
 	await fs.writeFile("./test/file.js", "export const x = 'hello'")
-	const env = await mockEnvironment({ copyDirectory: { fs, path: "./test" } })
+	const env = await mockEnvironment({ copyDirectory: { fs, paths: ["./test"] } })
 	const { x } = await env.$import("./test/file.js")
 	expect(x).toBe("hello")
 })
@@ -33,7 +47,7 @@ it("should give an error if the path does not exist (hinting at a current workin
 	// relative imports are relative to the current working directory, not the file.
 	// thus, if you run the tests from the root of the project, the path will be wrong.
 	try {
-		await mockEnvironment({ copyDirectory: { fs, path: "../test" } })
+		await mockEnvironment({ copyDirectory: { fs, paths: ["../test"] } })
 	} catch (error) {
 		expect(
 			(error as Error).message.includes(

--- a/source-code/core/src/test/mockEnvironment.ts
+++ b/source-code/core/src/test/mockEnvironment.ts
@@ -7,15 +7,15 @@ import dedent from "dedent"
  *
  * The mock environment uses a virtual file system (memfs). If
  * testing inlang depends on files in the local file system,
- * you can copy the directory into the environment by providing
+ * you can copy directories into the environment by providing
  * the `copyDirectory` argument.
  *
- * @param copyDirectory - if defined, copies the directory into the environment
+ * @param copyDirectory - if defined, copies directories (paths) into the environment
  */
 export async function mockEnvironment(args: {
 	copyDirectory?: {
 		fs: EnvironmentFunctions["$fs"]
-		path: string
+		paths: string[]
 	}
 }): Promise<EnvironmentFunctions> {
 	const $fs = memfs.promises as EnvironmentFunctions["$fs"]
@@ -28,8 +28,9 @@ export async function mockEnvironment(args: {
 		$import,
 	}
 	if (args.copyDirectory) {
-		const { fs, path } = args.copyDirectory
-		await copyDirectory({ copyFrom: fs, copyTo: $fs, path })
+		for (const path of args.copyDirectory.paths) {
+			await copyDirectory({ copyFrom: args.copyDirectory.fs, copyTo: $fs, path })
+		}
 	}
 	return env
 }

--- a/source-code/shared/lib/openai/src/generateConfigFile.server.ts
+++ b/source-code/shared/lib/openai/src/generateConfigFile.server.ts
@@ -42,7 +42,7 @@ export async function _generateConfigFileServer(args: {
 }): Promise<Result<string, Error>> {
 	const fs = Volume.fromJSON(args.filesystemAsJson).promises
 	// @ts-ignore
-	const env = await mockEnvironment({ copyDirectory: { fs: fs, path: "/" } })
+	const env = await mockEnvironment({ copyDirectory: { fs: fs, paths: ["/"] } })
 	if (args.messages === undefined) {
 		args.messages = [{ role: "system", content: prompt(Object.keys(args.filesystemAsJson)) }]
 	} else if (args.messages.length > 6) {


### PR DESCRIPTION
## Problem 

Copying multiple directories in mock environment was not possible. 

Copying multiple directories is important to test plugins.