### PR TITLE
sort languages in editor UI

### DIFF
--- a/source-code/website/src/pages/editor/@host/@owner/@repository/Messages.tsx
+++ b/source-code/website/src/pages/editor/@host/@owner/@repository/Messages.tsx
@@ -67,10 +67,6 @@ export function Messages(props: {
 		}
 	})
 
-	createEffect(() => {
-		console.log("test")
-	})
-
 	return (
 		<div ref={patternListElement}>
 			<Show

--- a/source-code/website/src/pages/editor/@host/@owner/@repository/State.tsx
+++ b/source-code/website/src/pages/editor/@host/@owner/@repository/State.tsx
@@ -221,6 +221,12 @@ export function EditorStateProvider(props: { children: JSXElement }) {
 		async (args) => {
 			const config = await readInlangConfig(args)
 			if (config) {
+				config.languages =
+					config.languages.sort((a, b) =>
+						// reference language should be first
+						// sort alphabetically otherwise
+						a === config.referenceLanguage ? -1 : a.localeCompare(b),
+					) || []
 				// initializes the languages to all languages
 				setFilteredLanguages(config.languages)
 			}


### PR DESCRIPTION
This PR makes sure that the reference language is always displayed at the first place