### PR TITLE
fix rpc client

### DIFF
--- a/source-code/env-variables/src/build/fetchPublicEnv.ts
+++ b/source-code/env-variables/src/build/fetchPublicEnv.ts
@@ -38,7 +38,7 @@ export async function fetchPublicEnv() {
 				console.log("✅ Fetched public env variables remotely.")
 			} else {
 				console.warn(
-					"⚠️ Fetched public env variables remotely but some are missing. Contact the maintainers.",
+					"⚠️ Fetched public env variables remotely but some are missing or invalid. Contact the maintainers.",
 				)
 				console.log(errors)
 			}

--- a/source-code/env-variables/src/schema.ts
+++ b/source-code/env-variables/src/schema.ts
@@ -15,6 +15,11 @@ export const publicEnvVariablesSchema = z.object({
 		.describe(`Must be a path like /git-proxy/`),
 	PUBLIC_SENTRY_DSN_CLIENT: z.string().optional(),
 	PUBLIC_POSTHOG_TOKEN: z.string().optional(),
+	PUBLIC_SERVER_BASE_URL: z
+		.string()
+		.url()
+		.regex(/^(?!.*\/$).+$/, "Must not end with a slash")
+		.describe("The base url of the server e.g. https://inlang.com"),
 })
 
 export const privateEnvVariablesSchema = z.object({

--- a/source-code/shared/lib/rpc/router.ts
+++ b/source-code/shared/lib/rpc/router.ts
@@ -1,7 +1,7 @@
 import express from "express"
 import bodyParser from "body-parser"
 import { rpcHandler } from "typed-rpc/lib/express.js"
-import { rpcs } from "./src/index.js"
+import { rpcs } from "./src/rpcs.js"
 
 export const rpcService = express.Router()
 // some rpcs can be quite large

--- a/source-code/shared/lib/rpc/src/client.ts
+++ b/source-code/shared/lib/rpc/src/client.ts
@@ -1,7 +1,8 @@
+import { publicEnv } from "@inlang/env-variables"
 import { rpcClient } from "typed-rpc"
 
 // ! Only import the type to not leak the implementation to the client
-import type { RpcService } from "./src/rpcs.js"
+import type { RpcService } from "./rpcs.js"
 
 // must be identical to path in route.ts
 const route = "/shared/rpc"
@@ -11,6 +12,4 @@ const route = "/shared/rpc"
  *
  * This is used by the client to call RPC functions.
  */
-export const rpc = rpcClient<RpcService>(
-	(process.env.DEV ? "http://localhost:3000" : "https://inlang.com") + route,
-)
+export const rpc = rpcClient<RpcService>(publicEnv.PUBLIC_SERVER_BASE_URL + route)

--- a/source-code/shared/lib/rpc/src/functions/machineTranslate.ts
+++ b/source-code/shared/lib/rpc/src/functions/machineTranslate.ts
@@ -1,5 +1,5 @@
 import type { Result } from "@inlang/core/utilities"
-import { telemetryNode } from "../../telemetry/index.js"
+import { telemetryNode } from "../../../telemetry/index.js"
 import { privateEnv } from "@inlang/env-variables"
 
 export async function machineTranslate(args: {

--- a/source-code/shared/lib/rpc/src/rpcs.ts
+++ b/source-code/shared/lib/rpc/src/rpcs.ts
@@ -1,4 +1,4 @@
-import { machineTranslate } from "./machineTranslate.js"
+import { machineTranslate } from "./functions/machineTranslate.js"
 
 export const rpcs = {
 	machineTranslate,


### PR DESCRIPTION
use env variable to determine the url for the client instead of relying on process.env which is (ofc) undefined in a browser context