### PR TITLE
Add posthog events

### DIFF
--- a/source-code/website/src/pages/editor/@host/@owner/@repository/components/PatternEditor.tsx
+++ b/source-code/website/src/pages/editor/@host/@owner/@repository/components/PatternEditor.tsx
@@ -209,6 +209,12 @@ export function PatternEditor(props: {
 	}
 
 	const handleShortcut = (event: KeyboardEvent) => {
+		telemetryBrowser.capture("onKeyDown", {
+			event: event,
+			targetLanguage: props.language,
+			owner: routeParams().owner,
+			repository: routeParams().repository,
+		})
 		if (event.code === "KeyS" && event.metaKey && hasChanges() && userIsCollaborator()) {
 			event.preventDefault()
 			handleCommit()
@@ -252,7 +258,14 @@ export function PatternEditor(props: {
 				prop:size="small"
 				prop:rows={1}
 				prop:placeholder="Enter translation ..."
-				onFocus={() => setIsFocused(true)}
+				onFocus={() => {
+					setIsFocused(true)
+					telemetryBrowser.capture("clicked in imputfield", {
+						targetLanguage: props.language,
+						owner: routeParams().owner,
+						repository: routeParams().repository,
+					})
+				}}
 				onFocusOut={(e) => {
 					if ((e.relatedTarget as Element)?.tagName !== "SL-BUTTON") {
 						setIsFocused(false)

--- a/source-code/website/src/pages/editor/@host/@owner/@repository/components/PatternEditor.tsx
+++ b/source-code/website/src/pages/editor/@host/@owner/@repository/components/PatternEditor.tsx
@@ -209,7 +209,7 @@ export function PatternEditor(props: {
 	}
 
 	const handleShortcut = (event: KeyboardEvent) => {
-		telemetryBrowser.capture("onKeyDown", {
+		telemetryBrowser.capture("onKeyDown input field", {
 			event: event,
 			targetLanguage: props.language,
 			owner: routeParams().owner,
@@ -260,7 +260,7 @@ export function PatternEditor(props: {
 				prop:placeholder="Enter translation ..."
 				onFocus={() => {
 					setIsFocused(true)
-					telemetryBrowser.capture("clicked in imputfield", {
+					telemetryBrowser.capture("onFocused imput field", {
 						targetLanguage: props.language,
 						owner: routeParams().owner,
 						repository: routeParams().repository,


### PR DESCRIPTION
Hey folks, 

I want to add a more granular funnel to the posthog insight `Contributor from GH -> Open pull request`. 
I added `onClick input field` and `onKeyDown input field`.
Need to test it in live.