### PR TITLE
chore: enable more typescript options

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
       - run: npm install --no-save
 
       - name: run format
-        run: npm run format
+        run: npm run format:fix
 
       - name: run linters
         run: npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -19327,7 +19327,7 @@
 			"version": "file:source-code/sdk-js",
 			"requires": {
 				"@inlang/core": "*",
-				"unplugin": "*"
+				"unplugin": "^1.3.1"
 			}
 		},
 		"@inlang/server": {

--- a/source-code/core/src/lint/linter.test.ts
+++ b/source-code/core/src/lint/linter.test.ts
@@ -11,7 +11,7 @@ vi.spyOn(console, "error").mockImplementation(vi.fn)
 const doLint = (rules: LintRule[], resources: Resource[]) => {
 	const config = {
 		// eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
-		referenceLanguage: resources[0]?.languageTag.name!,
+		referenceLanguage: resources[0]!.languageTag.name!,
 		languages: resources.map((resource) => resource.languageTag.name),
 		lint: { rules },
 	}
@@ -90,7 +90,7 @@ describe("lint", async () => {
 			}),
 		})
 		const [, errors] = await doLint([rule("error")], [cloned])
-		expect(errors?.length).toBe(1)
+		expect(errors!.length).toBe(1)
 		expect(errors![0]!.message.includes("inlang.someError"))
 	})
 

--- a/source-code/core/src/lint/linter.test.ts
+++ b/source-code/core/src/lint/linter.test.ts
@@ -10,7 +10,8 @@ vi.spyOn(console, "error").mockImplementation(vi.fn)
 
 const doLint = (rules: LintRule[], resources: Resource[]) => {
 	const config = {
-		referenceLanguage: resources[0]?.languageTag.name,
+		// eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
+		referenceLanguage: resources[0]?.languageTag.name!,
 		languages: resources.map((resource) => resource.languageTag.name),
 		lint: { rules },
 	}
@@ -90,7 +91,7 @@ describe("lint", async () => {
 		})
 		const [, errors] = await doLint([rule("error")], [cloned])
 		expect(errors?.length).toBe(1)
-		expect(errors![0].message.includes("inlang.someError"))
+		expect(errors![0]!.message.includes("inlang.someError"))
 	})
 
 	describe("rules", async () => {
@@ -174,9 +175,9 @@ describe("lint", async () => {
 
 			expect(onEnter).toHaveBeenCalledTimes(3)
 			const onEnterCalls = (onEnter as unknown as MockContext<Array<unknown>, unknown>).calls
-			expect(onEnterCalls[0][0]).toMatchObject({ type: "Resource" })
-			expect(onEnterCalls[1][0]).toMatchObject({ type: "Message" })
-			expect(onEnterCalls[2][0]).toMatchObject({ type: "Pattern" })
+			expect(onEnterCalls[0]![0]).toMatchObject({ type: "Resource" })
+			expect(onEnterCalls[1]![0]).toMatchObject({ type: "Message" })
+			expect(onEnterCalls[2]![0]).toMatchObject({ type: "Pattern" })
 		})
 
 		test("should visit all Message nodes from reference if not present in target", async () => {
@@ -188,8 +189,8 @@ describe("lint", async () => {
 			expect(onEnter).toHaveBeenCalledTimes(8)
 			const calls = (onEnter as unknown as MockContext<Array<unknown>, unknown>).calls
 
-			expect(calls[6][0]).toBeUndefined()
-			expect(calls[7][0]).toBeUndefined()
+			expect(calls[6]![0]).toBeUndefined()
+			expect(calls[7]![0]).toBeUndefined()
 		})
 
 		test("should visit all Message nodes from target even if not present in reference", async () => {
@@ -221,7 +222,7 @@ describe("lint", async () => {
 			expect(fn).toHaveBeenCalledTimes(1)
 			const calls = (fn as unknown as MockContext<Array<unknown>, unknown>).calls
 
-			expect(calls[0][0]).toStrictEqual(message)
+			expect(calls[0]![0]).toStrictEqual(message)
 		})
 
 		test("should await all functions", async () => {

--- a/source-code/core/src/lint/output.test.ts
+++ b/source-code/core/src/lint/output.test.ts
@@ -35,7 +35,7 @@ describe("printReport", async () => {
 		test("level", async () => {
 			printReport(report)
 
-			expect((console.error as unknown as MockContext<string[], void>).calls[0][0]).toContain(
+			expect((console.error as unknown as MockContext<string[], void>).calls[0]![0]).toContain(
 				"[error]",
 			)
 		})
@@ -43,7 +43,7 @@ describe("printReport", async () => {
 		test("id", async () => {
 			printReport(report)
 
-			expect((console.error as unknown as MockContext<string[], void>).calls[0][0]).toContain(
+			expect((console.error as unknown as MockContext<string[], void>).calls[0]![0]).toContain(
 				`(${report.id})`,
 			)
 		})
@@ -51,7 +51,7 @@ describe("printReport", async () => {
 		test("message", async () => {
 			printReport(reportWithMetadata)
 
-			expect((console.warn as unknown as MockContext<string[], void>).calls[0][0]).toContain(
+			expect((console.warn as unknown as MockContext<string[], void>).calls[0]![0]).toContain(
 				`${reportWithMetadata.message}`,
 			)
 		})
@@ -113,10 +113,10 @@ describe("print", async () => {
 		test("should print a separator for a resource", async () => {
 			print(lintedResource)
 
-			expect((console.info as unknown as MockContext<string[], void>).calls[0][0]).toContain(
+			expect((console.info as unknown as MockContext<string[], void>).calls[0]![0]).toContain(
 				"Resource",
 			)
-			expect((console.info as unknown as MockContext<string[], void>).calls[0][0]).toContain(
+			expect((console.info as unknown as MockContext<string[], void>).calls[0]![0]).toContain(
 				lintedResource.languageTag.name,
 			)
 		})
@@ -124,14 +124,14 @@ describe("print", async () => {
 		test("should print all reports for the current node", async () => {
 			print(lintedResource)
 
-			expect((console.info as unknown as MockContext<string[], void>).calls[1][0]).toContain(
-				`[${lintedResource.lint?.[0].level}]`,
+			expect((console.info as unknown as MockContext<string[], void>).calls[1]![0]).toContain(
+				`[${lintedResource.lint![0]!.level}]`,
 			)
-			expect((console.info as unknown as MockContext<string[], void>).calls[1][0]).toContain(
-				`(${lintedResource.lint?.[0].id})`,
+			expect((console.info as unknown as MockContext<string[], void>).calls[1]![0]).toContain(
+				`(${lintedResource.lint![0]!.id})`,
 			)
-			expect((console.info as unknown as MockContext<string[], void>).calls[1][0]).toContain(
-				lintedResource.lint?.[0].message,
+			expect((console.info as unknown as MockContext<string[], void>).calls[1]![0]).toContain(
+				lintedResource.lint![0]!.message,
 			)
 		})
 	})
@@ -151,31 +151,31 @@ describe("print", async () => {
 		test("should print a separator for a message", async () => {
 			print(lintedResource)
 
-			expect((console.info as unknown as MockContext<string[], void>).calls[2][0]).toContain(
+			expect((console.info as unknown as MockContext<string[], void>).calls[2]![0]).toContain(
 				"Resource",
 			)
-			expect((console.info as unknown as MockContext<string[], void>).calls[2][0]).toContain(
+			expect((console.info as unknown as MockContext<string[], void>).calls[2]![0]).toContain(
 				lintedResource.languageTag.name,
 			)
-			expect((console.info as unknown as MockContext<string[], void>).calls[2][0]).toContain(
+			expect((console.info as unknown as MockContext<string[], void>).calls[2]![0]).toContain(
 				"Message",
 			)
-			expect((console.info as unknown as MockContext<string[], void>).calls[2][0]).toContain(
-				lintedResource.body[0].id.name,
+			expect((console.info as unknown as MockContext<string[], void>).calls[2]![0]).toContain(
+				lintedResource.body[0]!.id.name,
 			)
 		})
 
 		test("should print all reports for the current node", async () => {
 			print(lintedResource)
 
-			expect((console.info as unknown as MockContext<string[], void>).calls[3][0]).toContain(
-				`[${lintedResource.body[0].lint?.[0].level}]`,
+			expect((console.info as unknown as MockContext<string[], void>).calls[3]![0]).toContain(
+				`[${lintedResource.body[0]!.lint![0]!.level}]`,
 			)
-			expect((console.info as unknown as MockContext<string[], void>).calls[3][0]).toContain(
-				`(${lintedResource.body[0].lint?.[0].id})`,
+			expect((console.info as unknown as MockContext<string[], void>).calls[3]![0]).toContain(
+				`(${lintedResource.body[0]!.lint![0]!.id})`,
 			)
-			expect((console.info as unknown as MockContext<string[], void>).calls[3][0]).toContain(
-				lintedResource.body[0].lint?.[0].message,
+			expect((console.info as unknown as MockContext<string[], void>).calls[3]![0]).toContain(
+				lintedResource.body[0]!.lint![0]!.message,
 			)
 		})
 	})
@@ -196,14 +196,14 @@ describe("print", async () => {
 		test("should print all reports for the current node", async () => {
 			print(lintedResource)
 
-			expect((console.info as unknown as MockContext<string[], void>).calls[4][0]).toContain(
-				`[${lintedResource.body[0].pattern.lint?.[0].level}]`,
+			expect((console.info as unknown as MockContext<string[], void>).calls[4]![0]).toContain(
+				`[${lintedResource.body[0]!.pattern.lint![0]!.level}]`,
 			)
-			expect((console.info as unknown as MockContext<string[], void>).calls[4][0]).toContain(
-				`(${lintedResource.body[0].pattern.lint?.[0].id})`,
+			expect((console.info as unknown as MockContext<string[], void>).calls[4]![0]).toContain(
+				`(${lintedResource.body[0]!.pattern.lint![0]!.id})`,
 			)
-			expect((console.info as unknown as MockContext<string[], void>).calls[4][0]).toContain(
-				lintedResource.body[0].pattern.lint?.[0].message,
+			expect((console.info as unknown as MockContext<string[], void>).calls[4]![0]).toContain(
+				lintedResource.body[0]!.pattern.lint![0]!.message,
 			)
 		})
 	})

--- a/source-code/core/src/query/index.test.ts
+++ b/source-code/core/src/query/index.test.ts
@@ -12,7 +12,7 @@ describe("query.create", () => {
 			},
 		})
 		const message = query(resource!).get({ id: "new-message-123" })
-		expect(message?.id.name).toBe("new-message-123")
+		expect(message!.id.name).toBe("new-message-123")
 	})
 	it("should return an error is the message already exists", () => {
 		const [, exception] = query(mockResource).create({
@@ -29,7 +29,7 @@ describe("query.create", () => {
 describe("query.get", () => {
 	it("should return the message if the message exists", () => {
 		const result = query(mockResource).get({ id: "first-message" })
-		expect(result?.id.name).toBe("first-message")
+		expect(result!.id.name).toBe("first-message")
 	})
 	it("should return undefined if the message does not exist", () => {
 		const result = query(mockResource).get({ id: "none-existent-message" })
@@ -39,7 +39,7 @@ describe("query.get", () => {
 		const result = query(mockResource).get({ id: "first-message" })
 		result!.id.name = "changed"
 		const queryAgain = query(mockResource).get({ id: "first-message" })
-		expect(queryAgain?.id.name).toBe("first-message")
+		expect(queryAgain!.id.name).toBe("first-message")
 	})
 })
 
@@ -52,7 +52,7 @@ describe("query.update", () => {
 			with: message!,
 		})
 		const updatedMessage = query(updatedResource!).get({ id: "first-message" })
-		expect(updatedMessage?.pattern.elements).toStrictEqual(message?.pattern.elements)
+		expect(updatedMessage!.pattern.elements).toStrictEqual(message!.pattern.elements)
 	})
 
 	it("should be immutable", () => {
@@ -63,7 +63,7 @@ describe("query.update", () => {
 			with: message!,
 		})
 		const queryMessageAgain = query(mockResource).get({ id: "first-message" })
-		expect(queryMessageAgain?.pattern.elements).not.toBe(message?.pattern.elements)
+		expect(queryMessageAgain!.pattern.elements).not.toBe(message!.pattern.elements)
 	})
 
 	it("should return an error if the message does not exist", () => {
@@ -87,7 +87,7 @@ describe("query.upsert", () => {
 		})
 
 		const message = query(resource!).get({ id: "new-message-1234" })
-		expect(message?.id.name).toBe("new-message-1234")
+		expect(message!.id.name).toBe("new-message-1234")
 	})
 
 	it("should update an existing message", () => {
@@ -97,7 +97,7 @@ describe("query.upsert", () => {
 			message: message!,
 		})
 		const updatedMessage = query(updatedResource!).get({ id: "first-message" })
-		expect(updatedMessage?.pattern.elements).toStrictEqual(message?.pattern.elements)
+		expect(updatedMessage!.pattern.elements).toStrictEqual(message!.pattern.elements)
 	})
 })
 

--- a/source-code/design-system/src/components/tailwindPlugin.cts
+++ b/source-code/design-system/src/components/tailwindPlugin.cts
@@ -106,11 +106,11 @@ function mapBorderRadius(args: {
 	)
 	switch (args.size) {
 		case "sm":
-			return tailwindThemeTokens["borderRadius"][indexOfBase - 1]
+			return tailwindThemeTokens["borderRadius"][indexOfBase - 1]!
 		case "DEFAULT":
-			return tailwindThemeTokens["borderRadius"][indexOfBase]
+			return tailwindThemeTokens["borderRadius"][indexOfBase]!
 		case "lg":
-			return tailwindThemeTokens["borderRadius"][indexOfBase + 1]
+			return tailwindThemeTokens["borderRadius"][indexOfBase + 1]!
 	}
 }
 

--- a/source-code/sdk-js/src/adapter-sveltekit/examples/lang-in-slug-static/src/hooks.server.ts
+++ b/source-code/sdk-js/src/adapter-sveltekit/examples/lang-in-slug-static/src/hooks.server.ts
@@ -14,7 +14,7 @@ export const handle = (async ({ event, resolve }) => {
 	const pathname = event.url.pathname
 	if (pathname.startsWith("/inlang")) return resolve(event)
 
-	const language = pathname.split("/")[1] || (undefined as unknown as string)
+	const language = pathname.split("/")[1]
 
 	const runtime = initRuntime({
 		readResource: (language: string) => getResource(language),

--- a/source-code/sdk-js/src/adapter-sveltekit/examples/lang-in-slug-static/tsconfig.json
+++ b/source-code/sdk-js/src/adapter-sveltekit/examples/lang-in-slug-static/tsconfig.json
@@ -9,6 +9,7 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
+		"noUncheckedIndexedAccess": true,
 		"moduleResolution": "node16"
 	}
 	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias

--- a/source-code/sdk-js/src/adapter-sveltekit/examples/lang-in-slug/tsconfig.json
+++ b/source-code/sdk-js/src/adapter-sveltekit/examples/lang-in-slug/tsconfig.json
@@ -9,6 +9,7 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
+		"noUncheckedIndexedAccess": true,
 		"moduleResolution": "node16"
 	}
 	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias

--- a/source-code/sdk-js/src/adapter-sveltekit/examples/spa-static/tsconfig.json
+++ b/source-code/sdk-js/src/adapter-sveltekit/examples/spa-static/tsconfig.json
@@ -9,6 +9,7 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
+		"noUncheckedIndexedAccess": true,
 		"moduleResolution": "node16"
 	}
 	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias

--- a/source-code/sdk-js/src/adapter-sveltekit/examples/spa/tsconfig.json
+++ b/source-code/sdk-js/src/adapter-sveltekit/examples/spa/tsconfig.json
@@ -9,6 +9,7 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
+		"noUncheckedIndexedAccess": true,
 		"moduleResolution": "node16"
 	}
 	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias

--- a/source-code/sdk-js/src/detectors/matchLanguage.ts
+++ b/source-code/sdk-js/src/detectors/matchLanguage.ts
@@ -39,4 +39,6 @@ export const matchLanguage = (
 			if (relatedLanguages.length) return relatedLanguages[0]
 		}
 	}
+
+	return undefined
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -37,6 +37,11 @@
 		"importsNotUsedAsValues": "error",
 		// tremendous helper to avoid hard to debug bugs.
 		// see https://github.com/inlang/inlang/issues/157
-		"noImplicitAny": true
+		"noUncheckedIndexedAccess": true,
+		"noImplicitAny": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitOverride": true,
+		"allowUnreachableCode": false,
 	}
 }


### PR DESCRIPTION
I was wondering why TypeScript didn't tell me that something could be undefined and I realized that we don't have enabled some TypeScript options. The most important one is probably `noUncheckedIndexedAccess`. When enabled it changes
```ts
names[0] // string
```
to
```ts
names[0] // string | undefined
```