### PR TITLE
refactor: align placeholder with upcoming message format 2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17269,6 +17269,7 @@
 			"name": "@inlang/badge",
 			"dependencies": {
 				"@inlang/core": "*",
+				"@inlang/telemetry": "*",
 				"@resvg/resvg-js": "^2.4.1",
 				"memfs": "^3.5.0",
 				"satori": "^0.4.7",
@@ -20266,6 +20267,7 @@
 			"version": "file:source-code/badge",
 			"requires": {
 				"@inlang/core": "*",
+				"@inlang/telemetry": "*",
 				"@resvg/resvg-js": "^2.4.1",
 				"memfs": "^3.5.0",
 				"satori": "^0.4.7",

--- a/source-code/badge/package.json
+++ b/source-code/badge/package.json
@@ -21,6 +21,7 @@
 	},
 	"dependencies": {
 		"@inlang/core": "*",
+		"@inlang/telemetry": "*",
 		"@resvg/resvg-js": "^2.4.1",
 		"memfs": "^3.5.0",
 		"satori": "^0.4.7",

--- a/source-code/badge/src/badge.ts
+++ b/source-code/badge/src/badge.ts
@@ -1,4 +1,3 @@
-// @prettier-ignore
 import satori from "satori"
 import clone from "./repo/clone.js"
 import { Config, EnvironmentFunctions, initialize$import } from "@inlang/core/config"
@@ -9,7 +8,6 @@ import { markup } from "./helper/markup.js"
 import { readFileSync } from "node:fs"
 import { telemetryNode } from "@inlang/telemetry"
 import { query } from "@inlang/core/query"
-import type * as ast from "@inlang/core/ast"
 
 const fontMedium = readFileSync(new URL("./assets/static/Inter-Medium.ttf", import.meta.url))
 const fontBold = readFileSync(new URL("./assets/static/Inter-Bold.ttf", import.meta.url))

--- a/source-code/core/src/ast/schema.ts
+++ b/source-code/core/src/ast/schema.ts
@@ -10,8 +10,7 @@ export type NodeName =
 	| "Text"
 	| "LanguageTag"
 	| "Placeholder"
-	| "Expression"
-	| "Variable"
+	| "VariableReference"
 
 /**
  * A utility type to extend any node with a new property.
@@ -110,18 +109,12 @@ export type Placeholder<Extension extends ExtensionInformation = ExtensionInform
 	"Placeholder",
 	Extension
 > & {
-	placeholder: Expression<Extension>
+	// only variable reference for now, but will be extended in the future
+	body: VariableReference<Extension>
 }
 
-export type Expression<Extension extends ExtensionInformation = ExtensionInformation> = Node<
-	"Expression",
-	Extension
-> & {
-	expression: Variable<Extension>
-}
-
-export type Variable<Extension extends ExtensionInformation = ExtensionInformation> = Node<
-	"Variable",
+export type VariableReference<Extension extends ExtensionInformation = ExtensionInformation> = Node<
+	"VariableReference",
 	Extension
 > & {
 	name: string

--- a/source-code/sdk-js/src/runtime/inlang-function.test.ts
+++ b/source-code/sdk-js/src/runtime/inlang-function.test.ts
@@ -32,12 +32,9 @@ const resource = {
 					{ type: "Text", value: "Welcome, " },
 					{
 						type: "Placeholder",
-						placeholder: {
-							type: "Expression",
-							expression: {
-								type: "Variable",
-								name: "name",
-							},
+						body: {
+							type: "VariableReference",
+							name: "name",
 						},
 					},
 					{ type: "Text", value: "!" },

--- a/source-code/sdk-js/src/runtime/inlang-function.ts
+++ b/source-code/sdk-js/src/runtime/inlang-function.ts
@@ -1,4 +1,4 @@
-import type { Expression, Message, Placeholder, Resource } from "@inlang/core/ast"
+import type { Message, Placeholder, Resource } from "@inlang/core/ast"
 
 type BaseArgs = Record<string, unknown> | never
 
@@ -41,21 +41,14 @@ const serializeElement = (
 		case "Text":
 			return element.value
 		case "Placeholder": {
-			return serializePlaceholder(element.placeholder, args)
+			return serializePlaceholder(element, args)
 		}
 	}
 }
 
-const serializePlaceholder = (placeholder: Placeholder["placeholder"], args: BaseArgs): string => {
-	switch (placeholder.type) {
-		case "Expression":
-			return serializeExpression(placeholder.expression, args)
-	}
-}
-
-const serializeExpression = (expression: Expression["expression"], args: BaseArgs): string => {
-	switch (expression.type) {
-		case "Variable":
-			return args[expression.name] as string
+const serializePlaceholder = (placeholder: Placeholder, args: BaseArgs): string => {
+	switch (placeholder.body.type) {
+		case "VariableReference":
+			return args[placeholder.body.name] as string
 	}
 }


### PR DESCRIPTION
_Closes #517_

I double-checked with both Flutent and the upcoming MessageFormat 2.0 AST. 

1. variable (references) are called variable references, not only "variable". I assume this because syntax can define variables that needs a separate node. 

2. expressions are unrelated to variables. variables are not nested in an expression. a placeholder contains either a variable reference or an expression whereas an expression is "a function" (something difficult like gender, pluralization etc)

We will introduce expressions at a later point in time. Unblocking @NilsJacobsen. @ivanhofer merge after review