### PR TITLE
fix node types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17009,7 +17009,7 @@
 		},
 		"source-code-git/fs": {
 			"name": "@inlang-git/fs",
-			"version": "0.0.1",
+			"version": "0.0.2",
 			"dependencies": {
 				"outmatch": "^0.7.0"
 			}
@@ -17033,7 +17033,7 @@
 		},
 		"source-code/cli": {
 			"name": "@inlang/cli",
-			"version": "0.5.5",
+			"version": "0.6.0",
 			"license": "MIT",
 			"dependencies": {
 				"ora": "^6.3.0",
@@ -17458,7 +17458,7 @@
 		},
 		"source-code/core": {
 			"name": "@inlang/core",
-			"version": "0.5.5",
+			"version": "0.6.0",
 			"dependencies": {
 				"@esbuild-plugins/node-modules-polyfill": "^0.2.2",
 				"@inlang-git/fs": "*",
@@ -17859,7 +17859,7 @@
 		"source-code/env-variables": {
 			"name": "@inlang/env-variables",
 			"dependencies": {
-				"@inlang/core": "^0.5.4",
+				"@inlang/core": "^0.6.0",
 				"dotenv": "^16.0.3",
 				"zod": "^3.21.4"
 			},
@@ -18389,7 +18389,7 @@
 		},
 		"source-code/sdk-js": {
 			"name": "@inlang/sdk-js",
-			"version": "0.0.1",
+			"version": "0.0.2",
 			"devDependencies": {
 				"@inlang/core": "*",
 				"@sveltejs/kit": "^1.15.9",
@@ -20515,7 +20515,7 @@
 		"@inlang/env-variables": {
 			"version": "file:source-code/env-variables",
 			"requires": {
-				"@inlang/core": "^0.5.4",
+				"@inlang/core": "^0.6.0",
 				"dotenv": "^16.0.3",
 				"esbuild": "^0.17.15",
 				"esbuild-plugin-d.ts": "^1.1.0",

--- a/source-code-git/fs/README.md
+++ b/source-code-git/fs/README.md
@@ -1,1 +1,6 @@
 # @inlang-git/fs
+
+## Guidelines
+
+1. Use NodeJS 20 `fs.promises` API for the interface. See https://github.com/inlang/inlang/pull/600#discussion_r1180103042. 
+2. Never use `any` in the filesystem interface. See https://github.com/inlang/inlang/pull/600#discussion_r1180090230. 

--- a/source-code-git/fs/src/implementations/implementations.test.ts
+++ b/source-code-git/fs/src/implementations/implementations.test.ts
@@ -48,11 +48,13 @@ const runFsTestSuite = async (name: string, tempDir: string, fs: NodeishFilesyst
 		expect(dirents).toContain("file2")
 		expect(dirents).toHaveLength(2)
 
-		expect(await fs.readFile(`${tempDir}/home/user1/documents/file1`, "utf8")).toEqual(
-			"text in the first file",
-		)
+		expect(
+			await fs.readFile(`${tempDir}/home/user1/documents/file1`, { encoding: "utf-8" }),
+		).toEqual("text in the first file")
 
-		expect(await fs.readFile(`${tempDir}/file2`, "utf8")).toEqual("text in the second file")
+		expect(await fs.readFile(`${tempDir}/file2`, { encoding: "utf-8" })).toEqual(
+			"text in the second file",
+		)
 	})
 
 	test.todo("encodings other than utf8")
@@ -72,18 +74,18 @@ const runFsTestSuite = async (name: string, tempDir: string, fs: NodeishFilesyst
 
 		test("writeFile", async () => {
 			await expect(
-				async () => await fs.readFile(`${tempDir}/home/dne/file`, "utf8"),
+				async () => await fs.readFile(`${tempDir}/home/dne/file`, { encoding: "utf-8" }),
 			).rejects.toThrow(/ENOENT/)
 		})
 
 		test("readFile", async () => {
-			await expect(async () => await fs.readFile(`${tempDir}/home/dne`, "utf8")).rejects.toThrow(
-				/ENOENT/,
-			)
+			await expect(
+				async () => await fs.readFile(`${tempDir}/home/dne`, { encoding: "utf-8" }),
+			).rejects.toThrow(/ENOENT/)
 
-			await expect(async () => await fs.readFile(`${tempDir}/home/user1`, "utf8")).rejects.toThrow(
-				/EISDIR/,
-			)
+			await expect(
+				async () => await fs.readFile(`${tempDir}/home/user1`, { encoding: "utf-8" }),
+			).rejects.toThrow(/EISDIR/)
 		})
 
 		test("readdir", async () => {
@@ -102,7 +104,7 @@ const runFsTestSuite = async (name: string, tempDir: string, fs: NodeishFilesyst
 
 		await fs.rm(`${tempDir}/home/user1/documents/file1`)
 		await expect(
-			async () => await fs.readFile(`${tempDir}/home/user1/documents/file1`, "utf8"),
+			async () => await fs.readFile(`${tempDir}/home/user1/documents/file1`, { encoding: "utf-8" }),
 		).rejects.toThrow(/ENOENT/)
 
 		await fs.writeFile(`${tempDir}/home/user1/documents/file1`, "text in the first file")

--- a/source-code-git/fs/src/implementations/memoryFs.ts
+++ b/source-code-git/fs/src/implementations/memoryFs.ts
@@ -1,4 +1,4 @@
-import type { FileData, TextEncoding, NodeishFilesystem } from "../interface.js"
+import type { FileData, NodeishFilesystem } from "../interface.js"
 import { FilesystemError } from "../errors/FilesystemError.js"
 
 type Directory = Map<string, MemoryInode>
@@ -13,22 +13,24 @@ export function createMemoryFs(): NodeishFilesystem {
 	const specialPaths = ["", ".", ".."]
 
 	return {
-		writeFile: async function (path: string, content: FileData) {
+		writeFile: async function (
+			path: Parameters<NodeishFilesystem["writeFile"]>[0],
+			data: Parameters<NodeishFilesystem["writeFile"]>[1],
+		) {
 			const parentDir: Inode | undefined = followPath(fsRoot, await getDirname(path), false)
-			if (parentDir instanceof Map) parentDir.set(await getBasename(path), content)
+			if (parentDir instanceof Map) parentDir.set(await getBasename(path), data)
 			else throw new FilesystemError("ENOENT", path)
 		},
 
 		readFile: async function (
-			path: string,
-			options?: { encoding?: TextEncoding } | TextEncoding,
-		): Promise<FileData> {
-			const encoding: TextEncoding =
-				typeof options === "string" ? options : options?.encoding ?? "raw"
+			path: Parameters<NodeishFilesystem["readFile"]>[0],
+			options: Parameters<NodeishFilesystem["readFile"]>[1],
+		) {
+			const encoding = typeof options === "string" ? options : options?.encoding ?? "raw"
 
 			const file: Inode | undefined = followPath(fsRoot, path)
 			if (typeof file === "string") {
-				if (["utf8", "utf-8"].includes(encoding?.toLowerCase())) return file
+				if (["utf8", "utf-8"].includes(encoding.toLowerCase())) return file
 				throw new Error(`Only utf8 encoding is supported in readFile.`)
 			}
 
@@ -36,7 +38,7 @@ export function createMemoryFs(): NodeishFilesystem {
 			throw new FilesystemError("EISDIR", path)
 		},
 
-		readdir: async function (path: string): Promise<string[]> {
+		readdir: async function (path: Parameters<NodeishFilesystem["readdir"]>[0]) {
 			const dir: Inode | undefined = followPath(fsRoot, path)
 			if (dir instanceof Map) return [...dir.keys()].filter((x) => !specialPaths.includes(x))
 			if (!dir) throw new FilesystemError("ENOENT", path)
@@ -44,9 +46,9 @@ export function createMemoryFs(): NodeishFilesystem {
 		},
 
 		mkdir: async function (
-			path: string,
-			options?: { recursive: boolean },
-		): Promise<string | undefined> {
+			path: Parameters<NodeishFilesystem["mkdir"]>[0],
+			options: Parameters<NodeishFilesystem["mkdir"]>[1],
+		) {
 			const parentDir: Inode | undefined = followPath(
 				fsRoot,
 				await getDirname(path),
@@ -59,7 +61,10 @@ export function createMemoryFs(): NodeishFilesystem {
 			return options?.recursive ? "not implemented." : undefined
 		},
 
-		rm: async function (path: string, options: any) {
+		rm: async function (
+			path: Parameters<NodeishFilesystem["rm"]>[0],
+			options: Parameters<NodeishFilesystem["rm"]>[1],
+		) {
 			const parentDir: Inode | undefined = followPath(fsRoot, await getDirname(path), false)
 			if (!parentDir) throw new FilesystemError("ENOENT", path)
 
@@ -79,7 +84,10 @@ export function createMemoryFs(): NodeishFilesystem {
 			} else throw new FilesystemError("ENOTDIR", path)
 		},
 
-		rmdir: async function (path: string, options: any) {
+		rmdir: async function (
+			path: Parameters<NodeishFilesystem["rmdir"]>[0],
+			options: Parameters<NodeishFilesystem["rmdir"]>[1],
+		) {
 			const parentDir: Inode | undefined = followPath(fsRoot, await getDirname(path), false)
 			if (!parentDir) throw new FilesystemError("ENOENT", path)
 

--- a/source-code-git/fs/src/interface.ts
+++ b/source-code-git/fs/src/interface.ts
@@ -8,8 +8,7 @@
  */
 export type NodeishFilesystem = {
 	writeFile: (path: string, data: string) => Promise<void>
-	/* NOTE: accept options as 'any' for now until we figure out how to get the node types to match */
-	readFile: (path: string, options?: any) => Promise<FileData>
+	readFile: (path: string, options: { encoding: "utf-8" }) => Promise<FileData>
 	readdir: (path: string) => Promise<string[]>
 	/**
 	 * https://nodejs.org/api/fs.html#fspromisesmkdirpath-options
@@ -18,8 +17,8 @@ export type NodeishFilesystem = {
 	 */
 	mkdir: (path: string, options?: { recursive: boolean }) => Promise<string | undefined>
 	rm: (path: string, options?: { recursive: boolean }) => Promise<void>
-	rmdir: (path: string, options?: any) => Promise<void>
+	rmdir: (path: string, options?: { recursive: boolean }) => Promise<void>
 }
 
 export type FileData = string
-export type TextEncoding = "utf8" | "utf-8" | "base64" | "raw"
+export type TextEncoding = "utf-8"

--- a/source-code-git/fs/src/interface.ts
+++ b/source-code-git/fs/src/interface.ts
@@ -21,4 +21,3 @@ export type NodeishFilesystem = {
 }
 
 export type FileData = string
-export type TextEncoding = "utf-8"

--- a/source-code-git/fs/src/utilities/toJson.ts
+++ b/source-code-git/fs/src/utilities/toJson.ts
@@ -52,7 +52,6 @@ export async function toJson(args: {
 		try {
 			await args.fs.readFile(fullPath, { encoding: "utf-8" })
 		} catch (error) {
-			console.log(error)
 			isDirectory = true
 		}
 		if (isDirectory) {


### PR DESCRIPTION
Fixes issues in #600. See the commit history for changes and explanations. 

@araknast We can enforce a super strict subset of node:fs/promises which we can widen over time. I encountered no type issues. 