### PR TITLE
feat: extend zod schema

### DIFF
--- a/source-code/core/src/ast/zod.ts
+++ b/source-code/core/src/ast/zod.ts
@@ -27,9 +27,19 @@ const Text = Node.extend({
 	value: z.string(),
 })
 
+const VariableReference = Node.extend({
+	type: z.literal("VariableReference"),
+	name: z.string(),
+})
+
+const Placeholder = Node.extend({
+	type: z.literal("Placeholder"),
+	body: VariableReference,
+})
+
 const Pattern = Node.extend({
 	type: z.literal("Pattern"),
-	elements: z.array(Text),
+	elements: z.array(Text, Placeholder),
 })
 
 const Message = Node.extend({


### PR DESCRIPTION
Hey folks, 

I wanted to implement placeholder support for the plugin json. I got a zod error, because Placeholder didn't fit the schema. So I extended the schema according to our ast schema. 

If there is nothing more to do I would merge it asap.
