### PR TITLE
Merge changes from inlang-git-fs into main

### DIFF
--- a/source-code-git/fs/src/errors/FilesystemError.ts
+++ b/source-code-git/fs/src/errors/FilesystemError.ts
@@ -2,23 +2,23 @@ export class FilesystemError extends Error {
 	code: string
 	path: string
 
-	constructor(code: string, path: string) {
+	constructor(code: string, path: string, syscall: string) {
 		let message
 		switch (code) {
 			case "ENOENT":
-				message = `${code}: No such file or directory. Path: "${path}"`
+				message = `${code}: No such file or directory, '${syscall}' on '${path}'`
 				break
 			case "ENOTDIR":
-				message = `${code}: Not a directory. Path: "${path}`
+				message = `${code}: Not a directory, Path: "${path}`
 				break
 			case "EISDIR":
-				message = `${code}: Illegal operation on a directory. Path: "${path}"`
+				message = `${code}: Illegal operation on a directory, '${syscall}' on '${path}'`
 				break
 			case "ENOTEMPTY":
-				message = `${code}: Directory not empty. Path: "${path}"`
+				message = `${code}: Directory not empty, '${syscall}' on '${path}'`
 				break
 			default:
-				message = `Unknown error with code "${code}". Path: "${path}"`
+				message = `Unknown error with code "${code}", '${syscall}' on '${path}'`
 		}
 		super(message)
 		this.name = "FilesystemError"

--- a/source-code-git/fs/src/implementations/memoryFs.ts
+++ b/source-code-git/fs/src/implementations/memoryFs.ts
@@ -147,16 +147,20 @@ function followPath(
 }
 
 async function getDirname(path: string): Promise<string> {
-	return path
-		.split("/")
-		.filter((x) => !["", "."].includes(x))
-		.slice(0, -1)
-		.join("/") ?? path
+	return (
+		path
+			.split("/")
+			.filter((x) => !["", "."].includes(x))
+			.slice(0, -1)
+			.join("/") ?? path
+	)
 }
 
 async function getBasename(path: string): Promise<string> {
-	return path
-		.split("/")
-		.filter((x) => !["", ".", ".."].includes(x))
-		.at(-1) ?? path
+	return (
+		path
+			.split("/")
+			.filter((x) => !["", ".", ".."].includes(x))
+			.at(-1) ?? path
+	)
 }

--- a/source-code-git/fs/src/implementations/memoryFs.ts
+++ b/source-code-git/fs/src/implementations/memoryFs.ts
@@ -7,7 +7,7 @@ type Directory = Map<string, Inode>
 export function createMemoryFs(): NodeishFilesystem {
 	// local state
 	const fsRoot = initDir(new Map())
-	const specialPaths = ["", ".", ".."]
+	const specialPaths = ["/", "", ".", ".."]
 
 	return {
 		writeFile: async function (
@@ -106,6 +106,7 @@ function initDir(parentDir: Directory) {
 	// Since these only exist internaly, there shouldn't be issues
 	// with serialization
 	const dir = new Map()
+	dir.set("/", dir)
 	dir.set("", dir)
 	dir.set(".", dir)
 	dir.set("..", parentDir)
@@ -150,12 +151,12 @@ async function getDirname(path: string): Promise<string> {
 		.split("/")
 		.filter((x) => !["", "."].includes(x))
 		.slice(0, -1)
-		.join("/")
+		.join("/") ?? path
 }
 
 async function getBasename(path: string): Promise<string> {
 	return path
 		.split("/")
 		.filter((x) => !["", ".", ".."].includes(x))
-		.at(-1)!
+		.at(-1) ?? path
 }


### PR DESCRIPTION
A few changes I made to `memoryFilesystem` whilst working on migrating the isomorphic-git tests and compatibility.

The first commit adds extends `FilesystemError` to also include the name of the command that produced the error, in line with node's FS implementation. I had originally implemented for my own personal use but I found it to be useful enough to warrant including in the actual implementation.

The second commit fixes a bug where calling `fs.mkdir('/')` would create a directory with `undefined` as it's key instead of a string. This was original due in part to a non-null assertion in `getBasename`, which has been replaced with a nullish coalesce to `path`. This also brings the behavior of `getBasename` and `getDirname` in line with their POSIX counterparts, now returning the path instead of an empty string when a basename is given. "/" has also been added to `specialPaths` since we can no longer count on it being filtered out by `getBasename` and `getDirname`.
