### PR TITLE
#709: support older `Svelte` versions

### DIFF
--- a/.changeset/dirty-singers-bow.md
+++ b/.changeset/dirty-singers-bow.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk-js": patch
+---
+
+add support for older Svelte versions

--- a/source-code/sdk-js/package.json
+++ b/source-code/sdk-js/package.json
@@ -49,6 +49,10 @@
 		"svelte-preprocess": "^5.0.3",
 		"ts-dedent": "^2.2.0"
 	},
+	"peerDependencies": {
+		"@sveltejs/kit": "^1.0.0",
+		"svelte": "^3.0.0"
+	},
 	"exports": {
 		".": "./dist/core/index.js",
 		"./adapter-sveltekit": "./dist/adapter-sveltekit/index.js",

--- a/source-code/sdk-js/src/adapter-sveltekit/runtime/client/reactive/index.ts
+++ b/source-code/sdk-js/src/adapter-sveltekit/runtime/client/reactive/index.ts
@@ -1,6 +1,6 @@
 import type * as Ast from "@inlang/core/ast"
 import { getContext, setContext } from "svelte"
-import { readonly, writable, type Readable } from "svelte/store"
+import { writable, type Readable } from "svelte/store"
 import type { RelativeUrl } from "../../../../core/index.js"
 import { inlangSymbol } from "../../shared/utils.js"
 import type { SvelteKitClientRuntime } from "../index.js"
@@ -56,3 +56,13 @@ export const addRuntimeToContext = (runtime: SvelteKitClientRuntime) => {
 
 // TODO: output warning that calling this does not make sense
 const route = (href: RelativeUrl) => href
+
+// ------------------------------------------------------------------------------------------------
+
+// copy from "svelte/store" to support older versions than `3.56.0`
+export function readonly<T>(store: Readable<T>): Readable<T> {
+	return {
+		// @ts-ignore
+		subscribe: store.subscribe.bind(store)
+	};
+}


### PR DESCRIPTION
closes #709