### PR TITLE
Remove `predev` script from `source-code-git/client/package.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18842,7 +18842,7 @@
 		},
 		"source-code/ide-extension": {
 			"name": "vs-code-extension",
-			"version": "0.5.5",
+			"version": "0.5.7",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@inlang/core": "*",
@@ -18866,7 +18866,7 @@
 		},
 		"source-code/ide-extension-plugin": {
 			"name": "@inlang/ide-extension-plugin",
-			"version": "0.5.5",
+			"version": "0.5.7",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@inlang/core": "^0.8.4",
@@ -19123,7 +19123,7 @@
 		},
 		"source-code/sdk-js": {
 			"name": "@inlang/sdk-js",
-			"version": "0.4.4",
+			"version": "0.4.5",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@inlang/core": "*",
@@ -19151,7 +19151,7 @@
 		},
 		"source-code/sdk-js-plugin": {
 			"name": "@inlang/sdk-js-plugin",
-			"version": "0.4.4",
+			"version": "0.4.5",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@inlang/core": "*",

--- a/source-code-git/client/package.json
+++ b/source-code-git/client/package.json
@@ -22,7 +22,6 @@
 		"---- BUILD --------------------------------------------------------": "",
 		"prebuild": "npm run isogit-update",
 		"build": "tsc --build ./tsconfig.build.json",
-		"predev": "npm run isogit-update",
 		"dev": "tsc --watch",
 		"---- TEST SETUP ----------------------------------------------------": "",
 		"start-proxy": "cors-proxy start -p 9999 -d",


### PR DESCRIPTION
With #752 merged this script becomes redundant. It also breaks the global `dev` script. Since `dev` scripts are now run in parallel it ends up tries to update the `isomorphic-git` package while other scripts are using it.