### PR TITLE
Don't use `--sparse` option when cloning isomorphic-git

### DIFF
--- a/source-code-git/client/package.json
+++ b/source-code-git/client/package.json
@@ -13,14 +13,9 @@
 		"./src"
 	],
 	"scripts": {
-		"---- BUILD SETUP --------------------------------------------------": "",
-		"isogit-clone": "rm -rf node_modules/isomorphic-git && git clone --depth=1 --sparse https://github.com/inlang/isomorphic-git node_modules/isomorphic-git",
-		"isogit-pull": "cd node_modules/isomorphic-git && git pull",
-		"isogit-http": "cd node_modules/isomorphic-git && git sparse-checkout add http",
-		"isogit-tests": "cd node_modules/isomorphic-git && git sparse-checkout add __tests__/__fixtures__/",
-		"isogit-update": "npm run isogit-clone; npm run isogit-pull && npm run isogit-http && npm run isogit-tests",
-		"---- BUILD --------------------------------------------------------": "",
-		"prebuild": "npm run isogit-update",
+		"---- BUILD AND DEV--------------------------------------------------": "",
+		"isogit-clone": "rm -rf node_modules/isomorphic-git && git clone --depth=1 https://github.com/inlang/isomorphic-git node_modules/isomorphic-git",
+		"prebuild": "npm run isogit-clone",
 		"build": "tsc --build ./tsconfig.build.json",
 		"dev": "tsc --watch",
 		"---- TEST SETUP ----------------------------------------------------": "",


### PR DESCRIPTION
The version of git used for deployments is out of date and does not support the `--sparse` option to `git clone`.