### PR TITLE
replace-btoa-and-atoa

### DIFF
--- a/.changeset/green-books-drop.md
+++ b/.changeset/green-books-drop.md
@@ -1,0 +1,5 @@
+---
+"@inlang-git/fs": patch
+---
+
+Fix utf-8 character support for toJson and fromJson

--- a/package-lock.json
+++ b/package-lock.json
@@ -10044,6 +10044,11 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/js-base64": {
+			"version": "3.7.5",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.5.tgz",
+			"integrity": "sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA=="
+		},
 		"node_modules/js-sdsl": {
 			"version": "4.3.0",
 			"dev": true,
@@ -17591,6 +17596,7 @@
 			"version": "0.0.3",
 			"license": "Apache-2.0",
 			"dependencies": {
+				"js-base64": "^3.7.5",
 				"outmatch": "^0.7.0"
 			}
 		},
@@ -17615,7 +17621,7 @@
 		},
 		"source-code/cli": {
 			"name": "@inlang/cli",
-			"version": "0.9.5",
+			"version": "0.9.7",
 			"license": "Apache-2.0",
 			"bin": {
 				"inlang": "bin/run.js"
@@ -21258,6 +21264,7 @@
 		"@inlang-git/fs": {
 			"version": "file:source-code-git/fs",
 			"requires": {
+				"js-base64": "*",
 				"outmatch": "^0.7.0"
 			}
 		},
@@ -21288,7 +21295,7 @@
 				"consola": "^2.15.3",
 				"esbuild": "^0.17.14",
 				"fast-glob": "^3.2.12",
-				"node-fetch": "^3.3.0",
+				"node-fetch": "^3.3.1",
 				"openai": "^3.2.1",
 				"ora": "^6.3.0",
 				"posthog-node": "^3.1.1",
@@ -27494,6 +27501,11 @@
 		"joycon": {
 			"version": "3.1.1",
 			"dev": true
+		},
+		"js-base64": {
+			"version": "3.7.5",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.5.tgz",
+			"integrity": "sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA=="
 		},
 		"js-sdsl": {
 			"version": "4.3.0",

--- a/source-code-git/fs/package.json
+++ b/source-code-git/fs/package.json
@@ -27,6 +27,7 @@
 		"clean": "rm -rf ./dist ./.turbo ./coverage ./node_modules"
 	},
 	"dependencies": {
+		"js-base64": "^3.7.5",
 		"outmatch": "^0.7.0"
 	},
 	"license": "Apache-2.0"

--- a/source-code-git/fs/src/utilities/fromJson.test.ts
+++ b/source-code-git/fs/src/utilities/fromJson.test.ts
@@ -75,16 +75,12 @@ it("should be able to make a binary roundtrip", async () => {
 // this test is a response to https://github.com/inlang/inlang/issues/811
 it("should work with characters outside of latin1", async () => {
 	const fs = createMemoryFs()
+	await fs.writeFile("/file4.txt", "👨‍👩‍👧")
+	const json = await toJson({ fs, matchers: ["**/*"], resolveFrom: "/" })
 	await fromJson({
 		fs,
 		resolveFrom: "/",
-		json: {
-			"file1.txt": "Y29udGVudDE=",
-			"file2.js": "Y29udGVudDI=",
-			"node_modules/file3.js": "Y29udGVudDM=",
-			"file4.txt": "4pyI",
-		},
+		json,
 	})
-
 	expect(await fs.readFile("/file4.txt", { encoding: "utf-8" })).toEqual("👨‍👩‍👧")
 })

--- a/source-code-git/fs/src/utilities/fromJson.test.ts
+++ b/source-code-git/fs/src/utilities/fromJson.test.ts
@@ -70,3 +70,21 @@ it("should be able to make a binary roundtrip", async () => {
 		await fs2.readFile("images/file3.png", { encoding: "binary" }),
 	)
 })
+
+// toJson and fromJson should encode and decode utf-8
+// this test is a response to https://github.com/inlang/inlang/issues/811
+it("should work with characters outside of latin1", async () => {
+	const fs = createMemoryFs()
+	await fromJson({
+		fs,
+		resolveFrom: "/",
+		json: {
+			"file1.txt": "Y29udGVudDE=",
+			"file2.js": "Y29udGVudDI=",
+			"node_modules/file3.js": "Y29udGVudDM=",
+			"file4.txt": "4pyI",
+		},
+	})
+
+	expect(await fs.readFile("/file4.txt", { encoding: "utf-8" })).toEqual("👨‍👩‍👧")
+})

--- a/source-code-git/fs/src/utilities/fromJson.ts
+++ b/source-code-git/fs/src/utilities/fromJson.ts
@@ -1,5 +1,6 @@
 import type { NodeishFilesystem } from "../interface.js"
 import { assertIsAbsolutePath } from "./assertIsAbsolutePath.js"
+import { decode as decodeBase64 } from "js-base64"
 
 /**
  * "Imports" files from a JSON into the filesystem.
@@ -17,6 +18,6 @@ export async function fromJson(args: {
 		const path = `${resolveFrom}/${filePath}`
 		await fs.mkdir(path, { recursive: true })
 
-		await fs.writeFile(path, atob(contents))
+		await fs.writeFile(path, decodeBase64(contents))
 	}
 }

--- a/source-code-git/fs/src/utilities/toJson.test.ts
+++ b/source-code-git/fs/src/utilities/toJson.test.ts
@@ -1,6 +1,7 @@
 import { it, describe, expect } from "vitest"
 import { createMemoryFs } from "../implementations/memoryFs.js"
 import { toJson } from "./toJson.js"
+import { fromJson } from "./fromJson.js"
 
 describe("toJson", async () => {
 	const fs = createMemoryFs()
@@ -41,11 +42,12 @@ describe("toJson", async () => {
 
 	// toJson and fromJson should encode and decode utf-8
 	// this test is a response to https://github.com/inlang/inlang/issues/811
-	it("should work with characters outside of latin1", () => {
+	it("should work with characters outside of latin1", async () => {
 		const fs = createMemoryFs()
 		fs.writeFile("/file1.txt", "👋")
-		expect(toJson({ fs, matchers: ["**/*"], resolveFrom: "/" })).toEqual({
-			"file1.txt": "8J+YgA==",
-		})
+		const json = await toJson({ fs, matchers: ["**/*"], resolveFrom: "/" })
+		const fs2 = createMemoryFs()
+		await fromJson({ fs: fs2, json, resolveFrom: "/" })
+		expect(await fs2.readFile("/file1.txt", { encoding: "utf-8" })).toEqual("👋")
 	})
 })

--- a/source-code-git/fs/src/utilities/toJson.test.ts
+++ b/source-code-git/fs/src/utilities/toJson.test.ts
@@ -38,4 +38,14 @@ describe("toJson", async () => {
 			"node_modules/file3.js": "Y29udGVudDM=",
 		})
 	})
+
+	// toJson and fromJson should encode and decode utf-8
+	// this test is a response to https://github.com/inlang/inlang/issues/811
+	it("should work with characters outside of latin1", () => {
+		const fs = createMemoryFs()
+		fs.writeFile("/file1.txt", "👋")
+		expect(toJson({ fs, matchers: ["**/*"], resolveFrom: "/" })).toEqual({
+			"file1.txt": "8J+YgA==",
+		})
+	})
 })

--- a/source-code-git/fs/src/utilities/toJson.ts
+++ b/source-code-git/fs/src/utilities/toJson.ts
@@ -3,6 +3,7 @@ import type { NodeishFilesystem } from "../interface.js"
 import outmatch from "outmatch"
 import { normalizePath } from "./normalizePath.js"
 import { assertIsAbsolutePath } from "./assertIsAbsolutePath.js"
+import { encode as encodeBase64 } from "js-base64"
 
 /**
  * Serializes the filesystem to a JSON object that can be sent over the network.
@@ -61,8 +62,7 @@ export async function toJson(args: {
 					`Badly behaved filesystem, expected string from readFile but got'${content.constructor.name}'.`,
 				)
 
-			console.log("going to btoa", content)
-			result[fullPath.slice(1)] = btoa(content) as string
+			result[fullPath.slice(1)] = encodeBase64(content)
 		}
 	}
 	return result


### PR DESCRIPTION
Btoa and atoa can't handle utf-8 encoding. Fixes btoa string to be encoded contains characters outside of latin1 range #811