### PR TITLE
Fix import path issue in sdk-js for Windows (#821)

### DIFF
--- a/source-code/sdk-js/src/adapter-sveltekit/vite-plugin/config.ts
+++ b/source-code/sdk-js/src/adapter-sveltekit/vite-plugin/config.ts
@@ -64,7 +64,7 @@ export const getTransformConfig = async (): Promise<TransformConfig> => {
 		const inlangConfig = await initConfig(inlangConfigModule)
 
 		const { default: svelteConfig } = (await import(
-			path.resolve(cwdFolderPath, "svelte.config.js")
+			pathToFileURL(path.resolve(cwdFolderPath, "svelte.config.js")).toString()
 		)) as { default: SvelteConfig }
 		const files = {
 			appTemplate: path.resolve(


### PR DESCRIPTION
This commit addresses an issue in the inlang sdk-js library where the import function was used to load the svelte.config.js file, resulting in a string that starts with the pattern "c:" on Windows systems. However, the import function expects a path beginning with "file://". This caused problems when starting the SvelteKit development environment or building for production.