### PR TITLE
Sdk-js: Respect SvelteKit base path config

### DIFF
--- a/.changeset/spicy-walls-remember.md
+++ b/.changeset/spicy-walls-remember.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk-js": patch
+---
+
+Solves #876 where the client produced by the SDK would not respect the base path configured in svelte.config.js

--- a/.changeset/spicy-walls-remember.md
+++ b/.changeset/spicy-walls-remember.md
@@ -2,4 +2,4 @@
 "@inlang/sdk-js": patch
 ---
 
-Solves #876 where the client produced by the SDK would not respect the base path configured in svelte.config.js
+add support for `path.base`

--- a/source-code/sdk-js/src/adapter-sveltekit/runtime/client/runtime.ts
+++ b/source-code/sdk-js/src/adapter-sveltekit/runtime/client/runtime.ts
@@ -1,4 +1,5 @@
 import type { LoadEvent } from "@sveltejs/kit"
+import { base } from "$app/paths"
 import { initRuntimeWithLanguageInformation } from "../../../runtime/index.js"
 
 type InitSvelteKitClientRuntimeArgs = {
@@ -16,7 +17,7 @@ export const initSvelteKitClientRuntime = async ({
 }: InitSvelteKitClientRuntimeArgs) => {
 	const runtime = initRuntimeWithLanguageInformation({
 		readResource: async (language: string) =>
-			fetch(`/inlang/${language}.json`).then((response) =>
+			fetch(`${base}/inlang/${language}.json`).then((response) =>
 				response.ok ? response.json() : undefined,
 			),
 		referenceLanguage,


### PR DESCRIPTION
This PR fixes #876

I wanted to include tests, but found no tests for the relevant files, and am uncertain of how to proceed.

Expected behaviour was confirmed by using the dist from the updated build in an mre.

Cases tested:

- `dev` and `preview` in SvelteKit without a base path configured.
- `dev` and `preview` in SvelteKit with a base path configured.
