### PR TITLE
fix: placeolder parsing creates empty Text elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18426,7 +18426,7 @@
 		},
 		"source-code/core": {
 			"name": "@inlang/core",
-			"version": "0.9.1",
+			"version": "0.9.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@esbuild-plugins/node-modules-polyfill": "^0.2.2",
@@ -19732,7 +19732,7 @@
 		},
 		"source-code/plugins/i18next": {
 			"name": "@inlang/plugin-i18next",
-			"version": "2.2.1",
+			"version": "2.2.2",
 			"devDependencies": {
 				"@inlang/core": "*",
 				"@size-limit/preset-app": "^8.2.4",
@@ -19815,7 +19815,7 @@
 		},
 		"source-code/plugins/json": {
 			"name": "@inlang/plugin-json",
-			"version": "3.0.4",
+			"version": "3.0.5",
 			"devDependencies": {
 				"@inlang/core": "*",
 				"@size-limit/preset-app": "^8.2.4",

--- a/source-code/plugins/i18next/src/plugin.test.ts
+++ b/source-code/plugins/i18next/src/plugin.test.ts
@@ -157,9 +157,9 @@ it("should remember if a file has a new line at the end or not", async () => {
 	expect(file2).toBe(withoutNewLine)
 })
 
-it("should correctly identify placeholders", async () => {
+it("should correctly identify placeholders without adding Text elements around it", async () => {
 	const enResource = `{
-    "test": "Hello {{username}}"
+    "test": "{{username}}"
 }`
 
 	const env = await mockEnvironment({})
@@ -175,6 +175,6 @@ it("should correctly identify placeholders", async () => {
 	const resources = await config.readResources!({
 		config: config as any,
 	})
-	expect(resources[0]?.body[0]?.pattern?.elements[0]?.type).toBe("Text")
-	expect(resources[0]?.body[0]?.pattern?.elements[1]?.type).toBe("Placeholder")
+	expect(resources[0]?.body[0]?.pattern?.elements[0]?.type).toBe("Placeholder")
+	expect(resources[0]?.body[0]?.pattern?.elements[1]).toBe(undefined)
 })

--- a/source-code/plugins/i18next/src/plugin.test.ts
+++ b/source-code/plugins/i18next/src/plugin.test.ts
@@ -157,7 +157,29 @@ it("should remember if a file has a new line at the end or not", async () => {
 	expect(file2).toBe(withoutNewLine)
 })
 
-it("should correctly identify placeholders without adding Text elements around it", async () => {
+it("should correctly identify placeholders", async () => {
+	const enResource = `{
+    "test": "Hello {{username}}"
+}`
+
+	const env = await mockEnvironment({})
+
+	await env.$fs.writeFile("./en.json", enResource)
+
+	const x = plugin({ pathPattern: "./{language}.json", variableReferencePattern: ["{{", "}}"] })(
+		env,
+	)
+	const config = await x.config({})
+	config.referenceLanguage = "en"
+	config.languages = ["en"]
+	const resources = await config.readResources!({
+		config: config as any,
+	})
+	expect(resources[0]?.body[0]?.pattern?.elements[0]?.type).toBe("Text")
+	expect(resources[0]?.body[0]?.pattern?.elements[1]?.type).toBe("Placeholder")
+})
+
+it("should parse Placeholders without adding Text elements around it", async () => {
 	const enResource = `{
     "test": "{{username}}"
 }`

--- a/source-code/plugins/i18next/src/plugin.ts
+++ b/source-code/plugins/i18next/src/plugin.ts
@@ -369,29 +369,31 @@ function parsePattern(
 				"g",
 		  )
 		: new RegExp(`(${variableReferencePattern}\\w+)`, "g")
-
-	const elements: ast.Pattern["elements"] = text.split(placeholder).map((element) => {
-		if (placeholder.test(element)) {
-			return {
-				type: "Placeholder",
-				body: {
-					type: "VariableReference",
-					name: variableReferencePattern[1]
-						? element.slice(
-								variableReferencePattern[0].length,
-								// negative index, removing the trailing pattern
-								-variableReferencePattern[1].length,
-						  )
-						: element.slice(variableReferencePattern[0].length),
-				},
+	const elements: ast.Pattern["elements"] = text
+		.split(placeholder)
+		.filter((element) => element !== "")
+		.map((element) => {
+			if (placeholder.test(element)) {
+				return {
+					type: "Placeholder",
+					body: {
+						type: "VariableReference",
+						name: variableReferencePattern[1]
+							? element.slice(
+									variableReferencePattern[0].length,
+									// negative index, removing the trailing pattern
+									-variableReferencePattern[1].length,
+							  )
+							: element.slice(variableReferencePattern[0].length),
+					},
+				}
+			} else {
+				return {
+					type: "Text",
+					value: element,
+				}
 			}
-		} else {
-			return {
-				type: "Text",
-				value: element,
-			}
-		}
-	})
+		})
 
 	return {
 		type: "Pattern",

--- a/source-code/plugins/json/src/plugin.test.ts
+++ b/source-code/plugins/json/src/plugin.test.ts
@@ -176,3 +176,25 @@ it("should correctly identify placeholders", async () => {
 	expect(resources[0]?.body[0]?.pattern?.elements[0]?.type).toBe("Text")
 	expect(resources[0]?.body[0]?.pattern?.elements[1]?.type).toBe("Placeholder")
 })
+
+it("should parse Placeholders without adding Text elements around it", async () => {
+	const enResource = `{
+    "test": "{{username}}"
+}`
+
+	const env = await mockEnvironment({})
+
+	await env.$fs.writeFile("./en.json", enResource)
+
+	const x = plugin({ pathPattern: "./{language}.json", variableReferencePattern: ["{{", "}}"] })(
+		env,
+	)
+	const config = await x.config({})
+	config.referenceLanguage = "en"
+	config.languages = ["en"]
+	const resources = await config.readResources!({
+		config: config as any,
+	})
+	expect(resources[0]?.body[0]?.pattern?.elements[0]?.type).toBe("Placeholder")
+	expect(resources[0]?.body[0]?.pattern?.elements[1]).toBe(undefined)
+})

--- a/source-code/plugins/json/src/plugin.ts
+++ b/source-code/plugins/json/src/plugin.ts
@@ -372,28 +372,31 @@ function parsePattern(
 		  )
 		: new RegExp(`(${variableReferencePattern}\\w+)`, "g")
 
-	const elements: ast.Pattern["elements"] = text.split(placeholder).map((element) => {
-		if (placeholder.test(element)) {
-			return {
-				type: "Placeholder",
-				body: {
-					type: "VariableReference",
-					name: variableReferencePattern[1]
-						? element.slice(
-								variableReferencePattern[0].length,
-								// negative index, removing the trailing pattern
-								-variableReferencePattern[1].length,
-						  )
-						: element.slice(variableReferencePattern[0].length),
-				},
+	const elements: ast.Pattern["elements"] = text
+		.split(placeholder)
+		.filter((element) => element !== "")
+		.map((element) => {
+			if (placeholder.test(element)) {
+				return {
+					type: "Placeholder",
+					body: {
+						type: "VariableReference",
+						name: variableReferencePattern[1]
+							? element.slice(
+									variableReferencePattern[0].length,
+									// negative index, removing the trailing pattern
+									-variableReferencePattern[1].length,
+							  )
+							: element.slice(variableReferencePattern[0].length),
+					},
+				}
+			} else {
+				return {
+					type: "Text",
+					value: element,
+				}
 			}
-		} else {
-			return {
-				type: "Text",
-				value: element,
-			}
-		}
-	})
+		})
 
 	return {
 		type: "Pattern",


### PR DESCRIPTION
Added the filter because we do not need to parse anything that is empty.
```ts
const elements: ast.Pattern["elements"] = text
		.split(placeholder)
		.filter((element) => element !== "")
		.map((element) => {
			if (placeholder.test(element)) {
				return {
					type: "Placeholder",
					body: {
						type: "VariableReference",
						name: variableReferencePattern[1]
							? element.slice(
									variableReferencePattern[0].length,
									// negative index, removing the trailing pattern
									-variableReferencePattern[1].length,
							  )
							: element.slice(variableReferencePattern[0].length),
					},
				}
			} else {
				return {
					type: "Text",
					value: element,
				}
			}
		})
```