### PR TITLE
chore: group output on tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
 				"lint-staged": "^13.1.2",
 				"patch-package": "^6.5.1",
 				"prettier": "2.8.3",
-				"turbo": "^1.9.9",
+				"turbo": "^1.10.6",
 				"typescript": "^4.9.4",
 				"vitest": "^0.29.8"
 			},
@@ -16713,27 +16713,27 @@
 			}
 		},
 		"node_modules/turbo": {
-			"version": "1.9.9",
-			"resolved": "https://registry.npmjs.org/turbo/-/turbo-1.9.9.tgz",
-			"integrity": "sha512-+ZS66LOT7ahKHxh6XrIdcmf2Yk9mNpAbPEj4iF2cs0cAeaDU3xLVPZFF0HbSho89Uxwhx7b5HBgPbdcjQTwQkg==",
+			"version": "1.10.6",
+			"resolved": "https://registry.npmjs.org/turbo/-/turbo-1.10.6.tgz",
+			"integrity": "sha512-0/wbjw4HvmPP1abVWHTdeFRfCA9cn5oxCPP5bDixagLzvDgGWE3xfdlsyGmq779Ekr9vjtDPgC2Y4JlXEhyryw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
 				"turbo": "bin/turbo"
 			},
 			"optionalDependencies": {
-				"turbo-darwin-64": "1.9.9",
-				"turbo-darwin-arm64": "1.9.9",
-				"turbo-linux-64": "1.9.9",
-				"turbo-linux-arm64": "1.9.9",
-				"turbo-windows-64": "1.9.9",
-				"turbo-windows-arm64": "1.9.9"
+				"turbo-darwin-64": "1.10.6",
+				"turbo-darwin-arm64": "1.10.6",
+				"turbo-linux-64": "1.10.6",
+				"turbo-linux-arm64": "1.10.6",
+				"turbo-windows-64": "1.10.6",
+				"turbo-windows-arm64": "1.10.6"
 			}
 		},
 		"node_modules/turbo-darwin-64": {
-			"version": "1.9.9",
-			"resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.9.9.tgz",
-			"integrity": "sha512-UDGM9E21eCDzF5t1F4rzrjwWutcup33e7ZjNJcW/mJDPorazZzqXGKEPIy9kXwKhamUUXfC7668r6ZuA1WXF2Q==",
+			"version": "1.10.6",
+			"resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.10.6.tgz",
+			"integrity": "sha512-s2Gc7i9Ud+H9GDcrGJjPIyscJfzDGQ6il4Sl2snfvwngJs4/TaqKuBoX3HNt/7F4NiFRs7ZhlLV1/Yu9zGBRhw==",
 			"cpu": [
 				"x64"
 			],
@@ -16744,9 +16744,9 @@
 			]
 		},
 		"node_modules/turbo-darwin-arm64": {
-			"version": "1.9.9",
-			"resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.9.9.tgz",
-			"integrity": "sha512-VyfkXzTJpYLTAQ9krq2myyEq7RPObilpS04lgJ4OO1piq76RNmSpX9F/t9JCaY9Pj/4TL7i0d8PM7NGhwEA5Ag==",
+			"version": "1.10.6",
+			"resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.10.6.tgz",
+			"integrity": "sha512-tgl70t5PBLyRcNTdP9N6NjvdvQ5LUk8Z60JGUhBhnc+oCOdA4pltrDJNPyel3tQAXXt1dDpl8pp9vUrbwoVyGg==",
 			"cpu": [
 				"arm64"
 			],
@@ -16757,9 +16757,9 @@
 			]
 		},
 		"node_modules/turbo-linux-64": {
-			"version": "1.9.9",
-			"resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.9.9.tgz",
-			"integrity": "sha512-Fu1MY29Odg8dHOqXcpIIGC3T63XLOGgnGfbobXMKdrC7JQDvtJv8TUCYciRsyknZYjyyKK1z6zKuYIiDjf3KeQ==",
+			"version": "1.10.6",
+			"resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.10.6.tgz",
+			"integrity": "sha512-h7eyAA3xtAVpamcYJYUwe0xm0LWdbv7/I7QiM09AZ67TTNpyUgqW8giFN3h793BHEQ2Rcnk9FNkpIbjWBbyamg==",
 			"cpu": [
 				"x64"
 			],
@@ -16770,9 +16770,9 @@
 			]
 		},
 		"node_modules/turbo-linux-arm64": {
-			"version": "1.9.9",
-			"resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.9.9.tgz",
-			"integrity": "sha512-50LI8NafPuJxdnMCBeDdzgyt1cgjQG7FwkyY336v4e95WJPUVjrHdrKH6jYXhOUyrv9+jCJxwX1Yrg02t5yJ1g==",
+			"version": "1.10.6",
+			"resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.10.6.tgz",
+			"integrity": "sha512-8cZhOeLqu3QZ27yLd6bw4FNaB8y5pLdWeRLJeiWHkIb/cptKnRKJFP+keBJzJi8ovaMqdBpabrxiBRN2lhau5Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -16783,9 +16783,9 @@
 			]
 		},
 		"node_modules/turbo-windows-64": {
-			"version": "1.9.9",
-			"resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.9.9.tgz",
-			"integrity": "sha512-9IsTReoLmQl1IRsy3WExe2j2RKWXQyXujfJ4fXF+jp08KxjVF4/tYP2CIRJx/A7UP/7keBta27bZqzAjsmbSTA==",
+			"version": "1.10.6",
+			"resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.10.6.tgz",
+			"integrity": "sha512-qx5jcfCJodN1Mh0KtSVQau7pK8CxDvtif7+joPHI2HbQPAADgdUl0LHfA5tFHh6aWgfvhxbvIXqJd6v7Mqkj9g==",
 			"cpu": [
 				"x64"
 			],
@@ -16796,9 +16796,9 @@
 			]
 		},
 		"node_modules/turbo-windows-arm64": {
-			"version": "1.9.9",
-			"resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.9.9.tgz",
-			"integrity": "sha512-CUu4hpeQo68JjDr0V0ygTQRLbS+/sNfdqEVV+Xz9136vpKn2WMQLAuUBVZV0Sp0S/7i+zGnplskT0fED+W46wQ==",
+			"version": "1.10.6",
+			"resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.10.6.tgz",
+			"integrity": "sha512-vTQaRG3/s2XTreOBr6J9HKFtjzusvwGQg0GtuW2+9Z7fizdzP8MuhaDbN6FhKHcWC81PQPD61TBIKTVTsYOEZg==",
 			"cpu": [
 				"arm64"
 			],
@@ -18317,7 +18317,7 @@
 		},
 		"source-code/cli": {
 			"name": "@inlang/cli",
-			"version": "0.11.3",
+			"version": "0.11.5",
 			"license": "Apache-2.0",
 			"bin": {
 				"inlang": "bin/run.js"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"build": "turbo run build",
 		"dev": "turbo run build --no-daemon && turbo run dev --parallel",
 		"---- TEST ----------------------------------------------------------": "",
-		"test": "turbo run test",
+		"test": "turbo run test --log-order=grouped",
 		"---- LINT ----------------------------------------------------------": "",
 		"lint:base": "eslint --ignore-path .gitignore --cache",
 		"lint:fix:base": "npm run lint:base --fix",
@@ -47,7 +47,7 @@
 		"lint-staged": "^13.1.2",
 		"patch-package": "^6.5.1",
 		"prettier": "2.8.3",
-		"turbo": "^1.9.9",
+		"turbo": "^1.10.6",
 		"typescript": "^4.9.4",
 		"vitest": "^0.29.8"
 	}


### PR DESCRIPTION
Turbo introduced a grouped output [recently.](https://github.com/vercel/turbo/releases/tag/v1.10.4) This helps to make the output of `npm run test` more readable. Before it looked like this:
![image](https://github.com/inlang/inlang/assets/1105080/fcb85bdb-e17e-4e86-9dfd-350c751eed72)

With grouped output it still runs parallel but collects until a task is finished (successfully or with an error).