### PR TITLE
Fix-vs-code-performance-issues

### DIFF
--- a/.changeset/rare-ways-unite.md
+++ b/.changeset/rare-ways-unite.md
@@ -1,0 +1,5 @@
+---
+"vs-code-extension": minor
+---
+
+Several performance improvements.

--- a/source-code/ide-extension/src/decorations/propertiesMissingPreview.ts
+++ b/source-code/ide-extension/src/decorations/propertiesMissingPreview.ts
@@ -1,8 +1,13 @@
 import { state } from "../state.js"
 import * as vscode from "vscode"
 
-export const propertiesMissingPreview = (args: { activeTextEditor: vscode.TextEditor }) => {
+export const propertiesMissingPreview = () => {
 	const ideExtension = state().config.ideExtension
+
+	const activeTextEditor = vscode.window.activeTextEditor
+	if (!activeTextEditor) {
+		return
+	}
 
 	if (!ideExtension) {
 		// create decoration in inlang.config.js file stating that the ideExtension properties are missing
@@ -17,13 +22,14 @@ export const propertiesMissingPreview = (args: { activeTextEditor: vscode.TextEd
 			},
 		})
 
-		const document = args.activeTextEditor.document
+		const document = activeTextEditor.document
+
 		const firstLine = document.lineAt(0)
 		const range = new vscode.Range(firstLine.range.start, firstLine.range.end)
 
 		// if the file is inlang.config.js -> decorate the first line with the decorationType
 		if (document.fileName.endsWith("inlang.config.js")) {
-			args.activeTextEditor.setDecorations(decorationType, [range])
+			activeTextEditor.setDecorations(decorationType, [range])
 		}
 	}
 }

--- a/source-code/ide-extension/src/main.ts
+++ b/source-code/ide-extension/src/main.ts
@@ -26,30 +26,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 			},
 		})
 		const gitOrigin = await getGitOrigin()
-		await telemetry.groupIdentify({
+		telemetry.groupIdentify({
 			groupType: "repository",
 			groupKey: gitOrigin,
 			properties: {
 				name: gitOrigin,
 			},
 		})
-
 		msg("Inlang extension activated.", "info")
-
-		// start the extension
+		// start the ide extension
 		main({ context })
-		// in case the active window changes -> restart the extension
-		// (could be improved in the future for performance reasons
-		// by detecting whether the closest config differs. For now,
-		// it's easier to restart the application each time.)
-		vscode.window.onDidChangeActiveTextEditor(() => {
-			// in case of running subscriptions -> dispose them (no commands will be shown anymore in the IDE)
-			for (const subscription of context.subscriptions) {
-				subscription.dispose()
-			}
-			// restart extension
-			main({ context })
-		})
 	} catch (error) {
 		vscode.window.showErrorMessage((error as Error).message)
 		console.error(error)
@@ -95,14 +81,10 @@ async function main(args: { context: vscode.ExtensionContext }): Promise<void> {
 
 	const config = await setupConfig({ module, env })
 
-	// shouldn't block the function from executing
-	// thus wrapped in async immediately executed function
-	;(async () => {
-		telemetry.capture({
-			event: coreUsedConfigEvent.name,
-			properties: coreUsedConfigEvent.properties(config),
-		})
-	})()
+	telemetry.capture({
+		event: coreUsedConfigEvent.name,
+		properties: coreUsedConfigEvent.properties(config),
+	})
 
 	const loadResources = async () => {
 		const resources = await config.readResources({ config })

--- a/source-code/ide-extension/src/main.ts
+++ b/source-code/ide-extension/src/main.ts
@@ -129,10 +129,10 @@ async function main(args: { context: vscode.ExtensionContext }): Promise<void> {
 	)
 
 	// register decorations
-	messagePreview({ activeTextEditor, context: args.context })
+	messagePreview(args)
 
 	// properties missing decoration in inlang.config.js
-	propertiesMissingPreview({ activeTextEditor })
+	propertiesMissingPreview()
 
 	// add inlang extension to recommended extensions
 	recommendation({ workspaceFolder })


### PR DESCRIPTION
likely fixes #1000 

### Changes

- don't restart the extension on every text editor change 
- message preview doesn't rely on state from the main function (to not restart the ide extension everytime) 
- remove debouncing from updateDecorations because the UX is laggy, and debouncing didn't lead to performance gains. I expect that vscode handles updating decorations internally very fast. 