### PR TITLE
fix(ide-extension): crash without git origin

### DIFF
--- a/.changeset/tender-eyes-leave.md
+++ b/.changeset/tender-eyes-leave.md
@@ -1,0 +1,5 @@
+---
+"vs-code-extension": patch
+---
+
+Fixes telemtry in ide-extension, so it won't crash if there is no git.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}/source-code/ide-extension",
 				// change this path to specify what folder should be opened upon running this configuration
-				"/tmp/test"
+				"${workspaceFolder}/source-code/starters/inlang-svelte"
 			],
 			"outFiles": [
 				"${workspaceFolder}/source-code/ide-extension/dist/**/*.cjs"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,9 +8,11 @@
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}/source-code/ide-extension",
 				// change this path to specify what folder should be opened upon running this configuration
-				"${workspaceFolder}/source-code/starters/inlang-svelte"
+				"/tmp/test"
 			],
-			"outFiles": ["${workspaceFolder}/source-code/ide-extension/dist/**/*.cjs"]
+			"outFiles": [
+				"${workspaceFolder}/source-code/ide-extension/dist/**/*.cjs"
+			]
 		},
 		{
 			"name": "debug @inlang/website",

--- a/source-code/ide-extension/src/main.ts
+++ b/source-code/ide-extension/src/main.ts
@@ -32,13 +32,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 			},
 		})
 		const gitOrigin = await getGitOrigin()
-		telemetry.groupIdentify({
-			groupType: "repository",
-			groupKey: gitOrigin,
-			properties: {
-				name: gitOrigin,
-			},
-		})
+		if (gitOrigin) {
+			telemetry.groupIdentify({
+				groupType: "repository",
+				groupKey: gitOrigin,
+				properties: {
+					name: gitOrigin,
+				},
+			})
+		}
 		msg("Inlang extension activated.", "info")
 		// start the ide extension
 		main({ context })

--- a/source-code/ide-extension/src/main.ts
+++ b/source-code/ide-extension/src/main.ts
@@ -31,18 +31,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 				autoConfigFileCreation: !(await isDisabledConfigFileCreation()),
 			},
 		})
-		try {
-			const gitOrigin = await getGitOrigin()
-			telemetry.groupIdentify({
-				groupType: "repository",
-				groupKey: gitOrigin,
-				properties: {
-					name: gitOrigin,
-				},
-			})
-		} catch (error) {
-			console.warn(error)
-		}
+		const gitOrigin = await getGitOrigin()
+		telemetry.groupIdentify({
+			groupType: "repository",
+			groupKey: gitOrigin,
+			properties: {
+				name: gitOrigin,
+			},
+		})
 		msg("Inlang extension activated.", "info")
 		// start the ide extension
 		main({ context })

--- a/source-code/ide-extension/src/services/telemetry/implementation.ts
+++ b/source-code/ide-extension/src/services/telemetry/implementation.ts
@@ -22,8 +22,8 @@ export const telemetry: Omit<typeof telemetryNode, "capture"> & { capture: typeo
  */
 type CaptureEventArguments =
 	| Omit<Parameters<typeof telemetryNode.capture>[0], "distinctId" | "groups"> & {
-			event: TelemetryEvents
-	  }
+		event: TelemetryEvents
+	}
 
 let gitOrigin: string
 let userID: string
@@ -60,14 +60,19 @@ async function capture(args: CaptureEventArguments) {
  * Gets the git origin url of the currently opened repository.
  */
 export async function getGitOrigin() {
-	const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
-	const remotes = await raw.listRemotes({
-		fs,
-		dir: await raw.findRoot({
+	try {
+		const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
+		const remotes = await raw.listRemotes({
 			fs,
-			filepath: workspaceRoot ?? process.cwd(),
-		}),
-	})
-	const gitOrigin = parseOrigin({ remotes })
-	return gitOrigin
+			dir: await raw.findRoot({
+				fs,
+				filepath: workspaceRoot ?? process.cwd(),
+			}),
+		})
+		const gitOrigin = parseOrigin({ remotes })
+		return gitOrigin
+	} catch (e) {
+		console.warn(e)
+		return 'without-git'
+	}
 }

--- a/source-code/ide-extension/src/services/telemetry/implementation.ts
+++ b/source-code/ide-extension/src/services/telemetry/implementation.ts
@@ -25,7 +25,7 @@ type CaptureEventArguments =
 		event: TelemetryEvents
 	}
 
-let gitOrigin: string
+let gitOrigin: string | undefined
 let userID: string
 
 /**
@@ -38,7 +38,7 @@ async function capture(args: CaptureEventArguments) {
 	if (userID === undefined) {
 		userID = await getUserId()
 	}
-	if (args.event === "IDE-EXTENSION activated") {
+	if (args.event === "IDE-EXTENSION activated" && gitOrigin) {
 		telemetry.groupIdentify({
 			groupType: "repository",
 			groupKey: gitOrigin,
@@ -50,9 +50,9 @@ async function capture(args: CaptureEventArguments) {
 	return telemetryNode.capture({
 		...args,
 		distinctId: userID,
-		groups: {
+		groups: gitOrigin ? {
 			repository: gitOrigin,
-		},
+		} : undefined,
 	})
 }
 
@@ -72,7 +72,6 @@ export async function getGitOrigin() {
 		const gitOrigin = parseOrigin({ remotes })
 		return gitOrigin
 	} catch (e) {
-		console.warn(e)
-		return 'without-git'
+		return undefined
 	}
 }


### PR DESCRIPTION
Uses `groupKey` "without-git", when there is no git origin