### PR TITLE
fail over on lint error and provide lint summary

### DIFF
--- a/.changeset/gentle-lizards-explain.md
+++ b/.changeset/gentle-lizards-explain.md
@@ -1,0 +1,5 @@
+---
+"@inlang/cli": minor
+---
+
+add `--no-fail` flag to lint command and output lint messages in tables

--- a/package-lock.json
+++ b/package-lock.json
@@ -6339,6 +6339,15 @@
 			"version": "1.2.0",
 			"dev": true
 		},
+		"node_modules/console-table-printer": {
+			"version": "2.11.2",
+			"resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.11.2.tgz",
+			"integrity": "sha512-uuUHie0sfPP542TKGzPFal0W1wo1beuKAqIZdaavcONx8OoqdnJRKjkinbRTOta4FaCa1RcIL+7mMJWX3pQGVg==",
+			"dev": true,
+			"dependencies": {
+				"simple-wcswidth": "^1.0.1"
+			}
+		},
 		"node_modules/constants-browserify": {
 			"version": "1.0.0",
 			"dev": true,
@@ -14855,6 +14864,12 @@
 				"simple-concat": "^1.0.0"
 			}
 		},
+		"node_modules/simple-wcswidth": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.0.1.tgz",
+			"integrity": "sha512-xMO/8eNREtaROt7tJvWJqHBDTMFN4eiQ5I4JRMuilwfnFcV5W9u7RUkueNkdw0jPqGMX36iCywelS5yilTuOxg==",
+			"dev": true
+		},
 		"node_modules/sirv": {
 			"version": "2.0.2",
 			"license": "MIT",
@@ -18365,6 +18380,7 @@
 				"@vscode/vsce": "^2.18.0",
 				"commander": "^10.0.0",
 				"consola": "^2.15.3",
+				"console-table-printer": "^2.11.2",
 				"esbuild": "^0.17.19",
 				"fast-glob": "^3.2.12",
 				"node-fetch": "^3.3.1",

--- a/source-code/cli/README.md
+++ b/source-code/cli/README.md
@@ -130,7 +130,9 @@ The lint command lints the translation with the configured lint rules, for examp
 npx @inlang/cli lint
 ```
 
-This command will read through all resources and find potential errors and warnings in the translation strings, for example with the [plugin-standard-lint-rules](https://github.com/inlang/plugin-standard-lint-rules), it searches for **missing messages**, **missing references** and **identical patterns / duplicates**.
+The `lint` command is provided with an optional `--no-fail` flag, which will not fail the command if there are any linting errors.
+
+`lint` will read through all resources and find potential errors and warnings in the translation strings, for example with the [plugin-standard-lint-rules](https://github.com/inlang/plugin-standard-lint-rules), it searches for **missing messages**, **missing references** and **identical patterns / duplicates**.
 
 However, it's totally up to you how you configure your lints. _You can build your own plugin with your customized set of lints_ with the [plugin-standard-lint-rules](https://github.com/inlang/plugin-standard-lint-rules) as a starter template.
 

--- a/source-code/cli/package.json
+++ b/source-code/cli/package.json
@@ -64,6 +64,7 @@
 		"@vscode/vsce": "^2.18.0",
 		"commander": "^10.0.0",
 		"consola": "^2.15.3",
+		"console-table-printer": "^2.11.2",
 		"esbuild": "^0.17.19",
 		"fast-glob": "^3.2.12",
 		"node-fetch": "^3.3.1",

--- a/source-code/cli/src/commands/lint/index.ts
+++ b/source-code/cli/src/commands/lint/index.ts
@@ -38,6 +38,11 @@ async function lintCommandAction() {
 		// Get lint report
 		const lints = getLintReports(resourcesWithLints)
 
+		if (lints.length === 0) {
+			log.success("🎉 Everything translated correctly.")
+			return
+		}
+
 		// Map over lints with correct log function
 		const lintTable = new Table({
 			title: "Lint Report",
@@ -102,8 +107,6 @@ async function lintCommandAction() {
 
 		if (hasError && lint.opts().fail) {
 			throw new Error("🚫 Lint failed with errors.")
-		} else if (!lints.length) {
-			log.success("🎉 Everything translated correctly.")
 		}
 	} catch (error) {
 		log.error(error)

--- a/source-code/cli/src/commands/lint/index.ts
+++ b/source-code/cli/src/commands/lint/index.ts
@@ -21,7 +21,7 @@ async function lintCommandAction() {
 		}
 
 		log.info(
-			"ℹ️  For this command to work, you need lint rules configured in your inlang.config.js – for example, through the https://github.com/inlang/plugin-standard-lint-rules plugin.",
+			"ℹ️  For this command to work, you need lint rules configured in your `inlang.config.js` – for example, through the https://github.com/inlang/plugin-standard-lint-rules plugin.",
 		)
 
 		const resources = await config.readResources({ config })
@@ -106,6 +106,9 @@ async function lintCommandAction() {
 		log.log(summaryTable.render())
 
 		if (hasError && lint.opts().fail) {
+			log.info(
+				"ℹ️  You can add the `--no-fail` flag to disable throwing an error if linting fails.",
+			)
 			throw new Error("🚫 Lint failed with errors.")
 		}
 	} catch (error) {

--- a/source-code/cli/src/commands/lint/index.ts
+++ b/source-code/cli/src/commands/lint/index.ts
@@ -1,13 +1,14 @@
-import { getLintReports, lint as _lint, LintReport } from "@inlang/core/lint"
+import { getLintReports, lint as _lint } from "@inlang/core/lint"
 import { Command } from "commander"
 import { cli } from "../../main.js"
 import { log } from "../../utilities.js"
-import { bold, italic } from "../../utilities/format.js"
+import { Table } from "console-table-printer"
 import { getConfig } from "../../utilities/getConfig.js"
 
 export const lint = new Command()
 	.command("lint")
 	.description("Commands for linting translations.")
+	.option("--no-fail", "Disable throwing an error if linting fails.") // defaults to false https://github.com/tj/commander.js#other-option-types-negatable-boolean-and-booleanvalue
 	.action(lintCommandAction)
 
 async function lintCommandAction() {
@@ -25,7 +26,7 @@ async function lintCommandAction() {
 
 		const resources = await config.readResources({ config })
 
-		// Get ressources with lints
+		// Get resources with lints
 		const [resourcesWithLints, errors] = await _lint({ resources, config })
 		if (errors) {
 			console.error(
@@ -34,25 +35,74 @@ async function lintCommandAction() {
 			)
 		}
 
-		// get lint report
+		// Get lint report
 		const lints = getLintReports(resourcesWithLints)
 
-		// map over lints with correct log function
-		lints.map((lint: LintReport) => {
-			switch (lint.level) {
-				case "error":
-					log.error(`Id: ${bold(lint.id)}, Message: ${italic(lint.message)}`)
-					break
-				case "warn":
-					log.error(`Id: ${bold(lint.id)}, Message: ${italic(lint.message)}`)
-					break
-				default:
-					log.info(`Id: ${bold(lint.id)}, Message: ${italic(lint.message)}`)
-					break
-			}
+		// Map over lints with correct log function
+		const lintTable = new Table({
+			title: "Lint Report",
+			columns: [
+				{ name: "Level", alignment: "left" },
+				{ name: "Lint Rule", alignment: "left" },
+				{ name: "Message", alignment: "left" },
+			],
 		})
 
-		if (!lints.length) {
+		let hasError = false
+
+		for (const lint of lints) {
+			switch (lint.level) {
+				case "error":
+					hasError = true
+					lintTable.addRow(
+						{ Level: "Error", "Lint Rule": lint.id, Message: lint.message },
+						{ color: "red" },
+					)
+					break
+				case "warn":
+					lintTable.addRow(
+						{ Level: "Warning", "Lint Rule": lint.id, Message: lint.message },
+						{ color: "yellow" },
+					)
+					break
+				default:
+					lintTable.addRow(
+						{ Level: "Info", "Lint Rule": lint.id, Message: lint.message },
+						{ color: "blue" },
+					)
+					break
+			}
+		}
+
+		log.log(lintTable.render())
+
+		// create summary table with total number of errors and warnings
+		const summaryTable = new Table({
+			title: "Lint Summary",
+			columns: [
+				{ name: "Level", alignment: "left" },
+				{ name: "Count", alignment: "left" },
+			],
+		})
+
+		summaryTable.addRow({
+			Level: "Error",
+			Count: lints.filter((lint) => lint.level === "error").length,
+		})
+		summaryTable.addRow({
+			Level: "Warning",
+			Count: lints.filter((lint) => lint.level === "warn").length,
+		})
+		summaryTable.addRow({
+			Level: "Info",
+			Count: lints.filter((lint) => lint.level === undefined).length,
+		})
+
+		log.log(summaryTable.render())
+
+		if (hasError && lint.opts().fail) {
+			throw new Error("🚫 Lint failed with errors.")
+		} else if (!lints.length) {
 			log.success("🎉 Everything translated correctly.")
 		}
 	} catch (error) {


### PR DESCRIPTION
this PR changes the default behavior of lint report to fail on errors and give a table output of the messages & a summary table with total numbers.