### PR TITLE
cli: add `config update`

### DIFF
--- a/.changeset/nice-ads-suffer.md
+++ b/.changeset/nice-ads-suffer.md
@@ -1,0 +1,5 @@
+---
+"@inlang/cli": minor
+---
+
+add `config update` command

--- a/package-lock.json
+++ b/package-lock.json
@@ -4993,9 +4993,10 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.8.2",
+			"version": "8.9.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
+			"integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
 			"dev": true,
-			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -18368,7 +18369,7 @@
 		},
 		"source-code/cli": {
 			"name": "@inlang/cli",
-			"version": "0.11.7",
+			"version": "0.12.0",
 			"license": "Apache-2.0",
 			"bin": {
 				"inlang": "bin/run.js"
@@ -18383,10 +18384,12 @@
 				"@types/prompts": "^2.4.2",
 				"@types/vscode": "^1.79.1",
 				"@vscode/vsce": "^2.18.0",
+				"acorn": "^8.9.0",
 				"commander": "^10.0.0",
 				"consola": "^2.15.3",
 				"console-table-printer": "^2.11.2",
 				"esbuild": "^0.17.19",
+				"estree-walker": "^3.0.3",
 				"fast-glob": "^3.2.12",
 				"node-fetch": "^3.3.1",
 				"openai": "^3.2.1",
@@ -18459,6 +18462,15 @@
 				"@esbuild/win32-arm64": "0.17.19",
 				"@esbuild/win32-ia32": "0.17.19",
 				"@esbuild/win32-x64": "0.17.19"
+			}
+		},
+		"source-code/cli/node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0"
 			}
 		},
 		"source-code/cli/node_modules/node-fetch": {
@@ -19786,7 +19798,7 @@
 		},
 		"source-code/plugins/i18next": {
 			"name": "@inlang/plugin-i18next",
-			"version": "2.2.4",
+			"version": "3.0.0",
 			"devDependencies": {
 				"@inlang/core": "*",
 				"@size-limit/preset-app": "^8.2.4",

--- a/source-code/cli/README.md
+++ b/source-code/cli/README.md
@@ -96,6 +96,18 @@ To validate the `inlang.config.js` file, run the following command:
 npx @inlang/cli config validate
 ```
 
+#### `config update`
+
+This command updates the `inlang.config.js` file with the latest versions of the plugins used. This is helpful if you want to update your plugins to the latest major version and don't want to look them up manually.
+
+Keep in mind updating to a new major version might break your configuration. We recommend to always check the changelog of the plugin before updating.
+
+To update the `inlang.config.js` file, run the following command:
+
+```sh
+npx @inlang/cli config update
+```
+
 ### `machine`
 
 The machine command is used to automate localization processes.

--- a/source-code/cli/README.md
+++ b/source-code/cli/README.md
@@ -98,9 +98,9 @@ npx @inlang/cli config validate
 
 #### `config update`
 
-This command updates the `inlang.config.js` file with the latest versions of the plugins used. This is helpful if you want to update your plugins to the latest major version and don't want to look them up manually.
+This command updates the `inlang.config.js` file with the latest versions of the plugins used. This is helpful if you want to **update your plugins** to the latest major version and don't want to look them up manually.
 
-Keep in mind updating to a new major version might break your configuration. We recommend to always check the changelog of the plugin before updating.
+Keep in mind updating to a new major version might break your configuration. _We recommend to always check the changelog of the plugin before updating._
 
 To update the `inlang.config.js` file, run the following command:
 

--- a/source-code/cli/package.json
+++ b/source-code/cli/package.json
@@ -73,7 +73,9 @@
 		"posthog-node": "^3.1.1",
 		"promptly": "^3.2.0",
 		"prompts": "^2.4.2",
-		"ts-dedent": "^2.2.0"
+		"ts-dedent": "^2.2.0",
+		"acorn": "^8.9.0",
+		"estree-walker": "^3.0.3"
 	},
 	"license": "Apache-2.0"
 }

--- a/source-code/cli/src/commands/config/index.ts
+++ b/source-code/cli/src/commands/config/index.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander"
 import { init } from "./init.js"
+import { update } from "./update.js"
 import { validate } from "./validate.js"
 
 export const config = new Command()
@@ -8,3 +9,4 @@ export const config = new Command()
 	.argument("<command>")
 	.addCommand(init)
 	.addCommand(validate)
+	.addCommand(update)

--- a/source-code/cli/src/commands/config/update.ts
+++ b/source-code/cli/src/commands/config/update.ts
@@ -1,4 +1,3 @@
-import { plugin } from "./../../../../plugins/json/src/plugin"
 import fs from "node:fs"
 import { Command } from "commander"
 import path from "node:path"

--- a/source-code/cli/src/commands/config/update.ts
+++ b/source-code/cli/src/commands/config/update.ts
@@ -1,0 +1,135 @@
+import { plugin } from "./../../../../plugins/json/src/plugin"
+import fs from "node:fs"
+import { Command } from "commander"
+import path from "node:path"
+import { cli } from "../../main.js"
+import { log } from "../../utilities.js"
+import { getLatestVersion } from "../../utilities/getLatestVersion.js"
+import prompts from "prompts"
+import { bold, italic } from "../../utilities/format.js"
+
+const configFile = "inlang.config.js"
+
+export const update = new Command()
+	.command("update")
+	.description("Update the inlang config.")
+	.action(updateCommandAction)
+
+async function updateCommandAction() {
+	try {
+		const answer = await prompts({
+			type: "confirm",
+			name: "update",
+			message:
+				"This command will update the plugins in you config file to the latest major version. Updating to a new major version can break the code, please look into the docs of the plugins you are using to see if there are breaking changes. Do you want to continue?",
+			initial: true,
+		})
+		if (answer.update === false) {
+			log.info("Aborting.")
+			return
+		}
+		log.info("Checking for new plugin versions...")
+		const filePath = cli.opts().config
+			? path.resolve(process.cwd(), cli.opts().config)
+			: path.resolve(process.cwd(), configFile)
+
+		const config = await readConfigFile(filePath)
+
+		// get the urls of the used plugins from the config file
+		const pluginURLs = extractPluginUrls(config)
+
+		// parse the urls
+		const pluginURLsParsed = pluginURLs.map((url) => {
+			const cleanedUrl = url.replace(/^"(.*)"$/, "$1") // Remove leading and trailing double quotes
+			const urlParts = cleanedUrl.split("/")
+			const nameWithVersion = urlParts[5]!
+			const [name, version] = nameWithVersion.split("@")
+			const publisher = urlParts[4]
+			return {
+				publisher: publisher,
+				name,
+				url: cleanedUrl,
+				version,
+			}
+		})
+
+		// get the latest version of each plugin
+		const pluginURLsWithLatestVersion = await Promise.all(
+			pluginURLsParsed.map(async (pluginURL) => {
+				const latestVersion = await getLatestVersion(pluginURL.publisher + "/" + pluginURL.name!)
+				return {
+					...pluginURL,
+					latestVersion,
+				}
+			}),
+		)
+
+		// for each  version, log which current version and which latest version will be used
+		for (const pluginURL of pluginURLsWithLatestVersion) {
+			log.info(
+				`📦 ${bold(`${pluginURL.publisher}/${pluginURL.name}`)} will be updated from v${italic(
+					`${pluginURL.version}`,
+				)} to v${italic(`${pluginURL.latestVersion}`)}`,
+			)
+		}
+
+		// add the latest version to the plugin urls
+		const pluginURLsWithUpdatedVersion = pluginURLsWithLatestVersion.map((pluginURL) => {
+			const updatedURL = updatePluginVersion(pluginURL.url, pluginURL.latestVersion!)
+			return {
+				...pluginURL,
+				updatedURL,
+			}
+		})
+
+		// replace the old urls with the new ones
+		const updatedConfig = pluginURLsWithUpdatedVersion.reduce((acc, pluginURL) => {
+			return acc.replace(pluginURL.url, pluginURL.updatedURL)
+		}, config)
+
+		// write the updated config file
+		await writeFile(filePath, updatedConfig)
+
+		log.success(`🎉 ${configFile} updated successfully.`)
+	} catch (err) {
+		log.error("❌ Failed to update plugin versions:", err)
+	}
+}
+
+function readConfigFile(filePath: string): Promise<string> {
+	return new Promise((resolve, reject) => {
+		fs.readFile(filePath, "utf8", (err, data) => {
+			if (err) {
+				reject(err)
+				return
+			}
+			try {
+				resolve(data)
+			} catch (err) {
+				reject(err)
+			}
+		})
+	})
+}
+
+function extractPluginUrls(code: string): string[] {
+	const urlRegex = /"(https?:\/\/.*?)(?=")/g
+	return [...code.matchAll(urlRegex)].map((match) => match[0]).map((url) => url.replace(/^"/, ""))
+}
+
+function updatePluginVersion(url: string, newVersion: string): string {
+	const versionRegex = /(@[\w.-]+)(?=\/dist\/index.js)/
+	return url.replace(versionRegex, `@${newVersion}`)
+}
+
+function writeFile(filePath: string, data: string): Promise<void> {
+	return new Promise((resolve, reject) => {
+		fs.writeFile(filePath, data, (err) => {
+			if (err) {
+				reject(err)
+				return
+			}
+			resolve()
+		})
+	})
+}

--- a/source-code/cli/src/main.ts
+++ b/source-code/cli/src/main.ts
@@ -72,11 +72,15 @@ telemetry.groupIdentify({
 	},
 })
 
-const [inlangConfig] = await getConfig({ options: cli.opts() })
+try {
+	const [inlangConfig] = await getConfig({ options: cli.opts() })
 
-if (inlangConfig) {
-	telemetry.capture({
-		event: coreUsedConfigEvent.name,
-		properties: coreUsedConfigEvent.properties(inlangConfig),
-	})
+	if (inlangConfig) {
+		telemetry.capture({
+			event: coreUsedConfigEvent.name,
+			properties: coreUsedConfigEvent.properties(inlangConfig),
+		})
+	}
+} catch (error) {
+	// ignore, because of telemetry usage
 }


### PR DESCRIPTION
#### `config update`

This command updates the `inlang.config.js` file with the latest versions of the plugins used. This is helpful if you want to **update your plugins** to the latest major version and don't want to look them up manually.

Keep in mind updating to a new major version might break your configuration. _We recommend to always check the changelog of the plugin before updating._

To update the `inlang.config.js` file, run the following command:

```sh
npx @inlang/cli config update
```