### PR TITLE
fix: doc submenu rendering

### DIFF
--- a/source-code/website/src/pages/documentation/index.page.server.tsx
+++ b/source-code/website/src/pages/documentation/index.page.server.tsx
@@ -33,11 +33,9 @@ await generateIndexAndTableOfContents()
 
 // should only run server side
 export const onBeforeRender: OnBeforeRender<PageProps> = async (pageContext) => {
-	let headings = []
 	// dirty way to get reload of markdown (not hot reload though)
 	if (import.meta.env.DEV) {
 		await generateIndexAndTableOfContents()
-		headings = await generateHeadings(pageContext.urlPathname)
 	}
 	if (!Object.keys(index).includes(pageContext.urlPathname)) {
 		throw RenderErrorPage({ pageContext: { is404: true } })
@@ -47,7 +45,6 @@ export const onBeforeRender: OnBeforeRender<PageProps> = async (pageContext) => 
 			pageProps: {
 				markdown: index[pageContext.urlPathname]!,
 				processedTableOfContents: processedTableOfContents,
-				headings: headings,
 			},
 		},
 	}
@@ -71,26 +68,4 @@ async function generateIndexAndTableOfContents() {
 		}
 		processedTableOfContents[category] = frontmatters
 	}
-}
-
-/**
- * Generates the headings
- */
-async function generateHeadings(urlPathname: string) {
-	const headings: PageProps["headings"] = []
-
-	const markdown = index[urlPathname]
-	if (markdown && markdown.renderableTree) {
-		for (const heading of markdown.renderableTree.children) {
-			if (heading.name === "Heading") {
-				if (heading.children[0].name) {
-					headings.push(heading.children[0])
-				} else {
-					headings.push(heading)
-				}
-			}
-		}
-	}
-
-	return headings
 }

--- a/source-code/website/src/pages/documentation/index.page.tsx
+++ b/source-code/website/src/pages/documentation/index.page.tsx
@@ -27,7 +27,7 @@ export function Page(props: PageProps) {
 
 		if (!props.markdown?.renderableTree) return
 
-		for (const heading of props.markdown?.renderableTree.children) {
+		for (const heading of props.markdown.renderableTree.children) {
 			if (heading.name === "Heading") {
 				if (heading.children[0].name) {
 					setHeadings((prev) => [...prev, heading.children[0].children[0]])

--- a/source-code/website/src/pages/documentation/index.page.tsx
+++ b/source-code/website/src/pages/documentation/index.page.tsx
@@ -16,20 +16,25 @@ import { useI18n } from "@solid-primitives/i18n"
 export type PageProps = {
 	processedTableOfContents: ProcessedTableOfContents
 	markdown: Awaited<ReturnType<typeof parseMarkdown>>
-	headings: any[]
 }
 
 export function Page(props: PageProps) {
 	let mobileDetailMenu: SlDetails | undefined
-	const [renderedHeadings, setRenderedHeadings] = createSignal<any[]>([])
+	const [headings, setHeadings] = createSignal<any[]>([])
 
 	createRenderEffect(() => {
-		setRenderedHeadings([])
+		setHeadings([])
 
-		if (!props.headings) return
+		if (!props.markdown?.renderableTree) return
 
-		for (const heading of props.headings) {
-			setRenderedHeadings((prev) => [...prev, heading.children[0]])
+		for (const heading of props.markdown?.renderableTree.children) {
+			if (heading.name === "Heading") {
+				if (heading.children[0].name) {
+					setHeadings((prev) => [...prev, heading.children[0].children[0]])
+				} else {
+					setHeadings((prev) => [...prev, heading.children[0]])
+				}
+			}
 		}
 	})
 
@@ -54,7 +59,7 @@ export function Page(props: PageProps) {
 							 */}
 							<div class="py-14 pr-8">
 								<Show when={props.processedTableOfContents}>
-									<NavbarCommon {...props} headings={renderedHeadings()} />
+									<NavbarCommon {...props} headings={headings()} />
 								</Show>
 							</div>
 						</nav>
@@ -71,7 +76,7 @@ export function Page(props: PageProps) {
 							<Show when={props.processedTableOfContents}>
 								<NavbarCommon
 									{...props}
-									headings={renderedHeadings()}
+									headings={headings()}
 									onLinkClick={() => {
 										mobileDetailMenu?.hide()
 									}}
@@ -116,7 +121,7 @@ export function Page(props: PageProps) {
 
 function NavbarCommon(props: {
 	processedTableOfContents: PageProps["processedTableOfContents"]
-	headings: PageProps["headings"]
+	headings: any[]
 	onLinkClick?: () => void
 }) {
 	const [highlightedAnchor, setHighlightedAnchor] = createSignal<string | undefined>("")
@@ -188,7 +193,7 @@ function NavbarCommon(props: {
 														{(heading) =>
 															heading !== undefined &&
 															heading !== document.frontmatter.shortTitle &&
-															props.headings.filter((h) => h === heading).length < 2 && (
+															props.headings.filter((h: any) => h === heading).length < 2 && (
 																<li>
 																	<a
 																		onClick={() => {

--- a/source-code/website/src/pages/documentation/index.page.tsx
+++ b/source-code/website/src/pages/documentation/index.page.tsx
@@ -212,7 +212,8 @@ function NavbarCommon(props: {
 																		href={`#${heading
 																			.toString()
 																			.toLowerCase()
-																			.replaceAll(" ", "-")}`}
+																			.replaceAll(" ", "-")
+																			.replaceAll("/", "")}`}
 																	>
 																		{heading}
 																	</a>

--- a/source-code/website/src/services/markdown/src/nodes/Heading.tsx
+++ b/source-code/website/src/services/markdown/src/nodes/Heading.tsx
@@ -73,8 +73,11 @@ const CopyWrapper = (props: { children: JSXElement }) => {
 					? typeof element === "object" && element instanceof HTMLDivElement
 						? element.innerText
 								?.toString()
-								.replaceAll(" ", "-")
 								.replace("#", "")
+								.replaceAll("/", "")
+								.replaceAll(/\(.*?\)/g, "")
+								.replaceAll(" ", "-")
+								.replace(/-$/, "")
 								.toLowerCase()
 								.trim() // Trim the value to remove any leading/trailing whitespace
 						: ""
@@ -96,7 +99,10 @@ const CopyWrapper = (props: { children: JSXElement }) => {
 									element?.innerText
 										?.toString()
 										.replaceAll(" ", "-")
+										.replaceAll("/", "")
+										.replaceAll(/\(.*?\)/g, "")
 										.replaceAll("#", "")
+										.replace(/-$/, "")
 										.toLowerCase()) as string,
 						  )
 						: copy(
@@ -104,7 +110,11 @@ const CopyWrapper = (props: { children: JSXElement }) => {
 									document.location.host +
 									document.location.pathname +
 									"#" +
-									props.children?.toString().replaceAll(" ", "-").toLowerCase()) as string,
+									props.children
+										?.toString()
+										.replaceAll(" ", "-")
+										.replace(/-$/, "")
+										.toLowerCase()) as string,
 						  )
 				}
 				showToast({ variant: "success", title: "Copied link to clipboard", duration: 3000 })


### PR DESCRIPTION
The headings of the newly added submenu weren't shown on the page (just when locally started).
Changed:
- Getting the headings now client-side from the markdown renderable tree
- As of the addition of https://inlang.com/documentation/sdk/sveltekit/advanced more bugs happened in the anchors, fixed them

@NilsJacobsen I'm assigning you because you already looked into #1084 and it's basically a fix for that.