### PR TITLE
[api spec] load config by createApp

### DIFF
--- a/source-code/core2/src/app/api.ts
+++ b/source-code/core2/src/app/api.ts
@@ -4,7 +4,7 @@ import type { MessagesQueryApi_1 } from "../messages/query.js"
 import type { InlangAppEnvironment } from "./env/types.js"
 
 export type InlangApp = {
-	config: Readonly<InlangConfig>
+	config: InlangConfig
 	env: InlangAppEnvironment
 	// TODO: exception handling
 	exceptions: InlangAppException[]

--- a/source-code/core2/src/app/api.ts
+++ b/source-code/core2/src/app/api.ts
@@ -1,13 +1,13 @@
 import type { InlangConfig } from "../config/schema.js"
 import type { LintException, LintReport } from "../lint/api.js"
 import type { MessagesQueryApi_1 } from "../messages/query.js"
-import type { InlangAppEnvironment } from "./env/types.js"
+import type { InlangInstanceEnv } from "./env/types.js"
 
-export type InlangApp = {
-	config: InlangConfig
-	env: InlangAppEnvironment
+export type InlangInstance = {
+	config: Readonly<InlangConfig>
+	env: InlangInstanceEnv
 	// TODO: exception handling
-	exceptions: InlangAppException[]
+	exceptions: InlangInstanceException[]
 	messages: {
 		query: MessagesQueryApi_1
 	}
@@ -19,9 +19,9 @@ export type InlangApp = {
 	}
 }
 
-class InlangAppException extends Error {
+class InlangInstanceException extends Error {
 	constructor(message: string) {
 		super(message)
-		this.name = "InlangAppException"
+		this.name = "InlangInstanceException"
 	}
 }

--- a/source-code/core2/src/app/createApp.ts
+++ b/source-code/core2/src/app/createApp.ts
@@ -1,7 +1,6 @@
-import type { InlangConfig } from "../config/schema.js"
 import type { InlangApp } from "./api.js"
 import type { InlangAppEnvironment } from "./env/types.js"
 
-export function createApp(args: { config: InlangConfig; env: InlangAppEnvironment }): InlangApp {
+export function createApp(args: { configPath: string; env: InlangAppEnvironment }): InlangApp {
 	return {} as any
 }

--- a/source-code/core2/src/app/createApp.ts
+++ b/source-code/core2/src/app/createApp.ts
@@ -1,6 +1,0 @@
-import type { InlangApp } from "./api.js"
-import type { InlangAppEnvironment } from "./env/types.js"
-
-export function createApp(args: { configPath: string; env: InlangAppEnvironment }): InlangApp {
-	return {} as any
-}

--- a/source-code/core2/src/app/createInlang.ts
+++ b/source-code/core2/src/app/createInlang.ts
@@ -1,0 +1,10 @@
+import type { InlangConfig } from "../config/schema.js"
+import type { InlangInstance } from "./api.js"
+import type { InlangInstanceEnv } from "./env/types.js"
+
+export function createInlang(args: {
+	config: InlangConfig
+	env: InlangInstanceEnv
+}): InlangInstance {
+	return {} as any
+}

--- a/source-code/core2/src/app/env/types.ts
+++ b/source-code/core2/src/app/env/types.ts
@@ -3,7 +3,7 @@
  *
  * Read more https://inlang.com/documentation/inlang-environment
  */
-export type InlangAppEnvironment = {
+export type InlangInstanceEnv = {
 	fs: any
 	import: any
 }

--- a/source-code/core2/src/fullExample.ts
+++ b/source-code/core2/src/fullExample.ts
@@ -1,4 +1,4 @@
-import { createApp } from "./app/createApp.js"
+import { createInlang } from "./app/createInlang.js"
 import type { InlangConfig } from "./config/schema.js"
 import type {  MessageLintRule } from "./lint/api.js"
 import type { Plugin_Proposal_2 } from "./plugin/api.js"
@@ -68,8 +68,8 @@ const exampleInlangConfig: InlangConfig = {
 
 // 1. Create the app instance
 //    - env needs be created
-const inlang = createApp({
-	configPath: "/hello/inlang.config.json",
+const inlang = createInlang({
+	config,
 	env: { fs: undefined as any, import: undefined as any },
 })
 

--- a/source-code/core2/src/fullExample.ts
+++ b/source-code/core2/src/fullExample.ts
@@ -12,25 +12,20 @@ const missingMessage: MessageLintRule = {
 		de: "Fehlende Nachricht",
 	},
 	defaultLevel: "error",
-	type: "Message",
-	message: ({ message, inlang }) => {
+	message: ({ message, inlang, report }) => {
 		if (message.languageTag !== inlang.config.sourceLanguageTag) {
 			return
 		}
-		// TODO pain to make reports typesafe...
-		// - MessageLintReport has a lot of duplicate information
-		const reports = []
 		for (const languageTag of inlang.config.languageTags) {
 			const translation = inlang.messages.query.get({ where: { id: message.id, languageTag } })
 			if (!translation) {
-				reports.push({
+				report({
 					languageTag,
 					messageId: message.id,
 					content: `Message "${message.id}" is missing in language tag "${languageTag}".`,
 				})
 			}
 		}
-		return reports
 	},
 }
 

--- a/source-code/core2/src/fullExample.ts
+++ b/source-code/core2/src/fullExample.ts
@@ -95,6 +95,9 @@ inlang.messages.query.delete({ where: { id: "myMessageId", languageTag: "en" } }
 inlang.config.sourceLanguageTag
 inlang.config.languageTags
 
+// adding a language tag via an app
+inlang.config.languageTags = [...inlang.config.languageTags, "de-AT"]
+
 // --- LINT ---
 inlang.lint.reports.filter((report) => report.level === "error")
 inlang.lint.exceptions

--- a/source-code/core2/src/fullExample.ts
+++ b/source-code/core2/src/fullExample.ts
@@ -89,8 +89,6 @@ inlang.messages.query.update({ where: { id: "myMessageId", languageTag: "en" }, 
 inlang.messages.query.delete({ where: { id: "myMessageId", languageTag: "en" } })
 
 // --- CONFIG ACCESS ---
-//   - config is static. adjusting the config requires a re-initialization of the app.
-//     IMHO (@samuelstroschein) that okay. 
 
 inlang.config.sourceLanguageTag
 inlang.config.languageTags

--- a/source-code/core2/src/fullExample.ts
+++ b/source-code/core2/src/fullExample.ts
@@ -57,6 +57,7 @@ export const myPlugin: Plugin_Proposal_2<{ pathPattern: string }> = {
 // --- SETUP ---
 
 // 0. Example config on disk
+//   "/hello/inlang.config.json"
 const exampleInlangConfig: InlangConfig = {
 	sourceLanguageTag: "en",
 	languageTags: ["en"],
@@ -70,15 +71,10 @@ const exampleInlangConfig: InlangConfig = {
   }
 }
 
-// 1. The JSON config needs to be read manually.  
-//    - an app instance can't know where a config is located
-//    - gives apps more freedom to load different configs if desired (testing, etc.)
-const config = fs.readFile("./inlang.config.json")
-
-// 2. Create the app instance
+// 1. Create the app instance
 //    - env needs be created
 const inlang = createApp({
-	config,
+	configPath: "/hello/inlang.config.json",
 	env: { fs: undefined as any, import: undefined as any },
 })
 

--- a/source-code/core2/src/lint/api.ts
+++ b/source-code/core2/src/lint/api.ts
@@ -13,16 +13,15 @@ export type LintRule = {
 	defaultLevel: "error" | "warn"
 }
 
-// TODO better "message" agnostic way for linting system?
-// - Trying to make the lint system "message" agnostic.
-//
 export type MessageLintRule = LintRule & {
-	type: "Message"
-	message: (args: {
-		message: Message
-		inlang: InlangApp
-	}) => MaybeArray<Omit<MessageLintReport, "ruleId" | "level" | "type">> | undefined | void
+	message: (args: { message: Message; inlang: InlangApp; report: ReportMessageLint }) => void
 }
+
+export type ReportMessageLint = (args: {
+	messageId: Message["id"]
+	languageTag: LanguageTag
+	content: LintReport["content"]
+}) => MessageLintReport
 
 export type LintReport = {
 	ruleId: LintRule["id"]
@@ -42,5 +41,3 @@ export class LintException extends Error {
 		this.name = "LintException"
 	}
 }
-
-type MaybeArray<T> = T | T[]


### PR DESCRIPTION
## Problem 

Changing the user config via an app becomes impossible if the `createApp` instance doesn't know how to write changes of the config back to the filesystem. 

## Proposal 

Pass the path of a config to `createApp`; let `createApp` read (and write) the config. 

**Pros**

- apps can very easily perform CRUD ops on the user config
- apps don't need to reinitialize `createApp` (bad UX) 

**Cons**

- [neglactable] testing becomes slightly harder because one must call fs.writeFile("inlang.config.json") before. 