### PR TITLE
[api spec] rename app to instance

### DIFF
--- a/source-code/core2/src/app/api.ts
+++ b/source-code/core2/src/app/api.ts
@@ -1,13 +1,13 @@
 import type { InlangConfig } from "../config/schema.js"
 import type { LintException, LintReport } from "../lint/api.js"
 import type { MessagesQueryApi_1 } from "../messages/query.js"
-import type { InlangAppEnvironment } from "./env/types.js"
+import type { InlangInstanceEnv } from "./env/types.js"
 
-export type InlangApp = {
+export type InlangInstance = {
 	config: Readonly<InlangConfig>
-	env: InlangAppEnvironment
+	env: InlangInstanceEnv
 	// TODO: exception handling
-	exceptions: InlangAppException[]
+	exceptions: InlangInstanceException[]
 	messages: {
 		query: MessagesQueryApi_1
 	}
@@ -19,9 +19,9 @@ export type InlangApp = {
 	}
 }
 
-class InlangAppException extends Error {
+class InlangInstanceException extends Error {
 	constructor(message: string) {
 		super(message)
-		this.name = "InlangAppException"
+		this.name = "InlangInstanceException"
 	}
 }

--- a/source-code/core2/src/app/createApp.ts
+++ b/source-code/core2/src/app/createApp.ts
@@ -1,7 +1,0 @@
-import type { InlangConfig } from "../config/schema.js"
-import type { InlangApp } from "./api.js"
-import type { InlangAppEnvironment } from "./env/types.js"
-
-export function createApp(args: { config: InlangConfig; env: InlangAppEnvironment }): InlangApp {
-	return {} as any
-}

--- a/source-code/core2/src/app/createInlang.ts
+++ b/source-code/core2/src/app/createInlang.ts
@@ -1,0 +1,10 @@
+import type { InlangConfig } from "../config/schema.js"
+import type { InlangInstance } from "./api.js"
+import type { InlangInstanceEnv } from "./env/types.js"
+
+export function createInlang(args: {
+	config: InlangConfig
+	env: InlangInstanceEnv
+}): InlangInstance {
+	return {} as any
+}

--- a/source-code/core2/src/app/env/types.ts
+++ b/source-code/core2/src/app/env/types.ts
@@ -3,7 +3,7 @@
  *
  * Read more https://inlang.com/documentation/inlang-environment
  */
-export type InlangAppEnvironment = {
+export type InlangInstanceEnv = {
 	fs: any
 	import: any
 }

--- a/source-code/core2/src/fullExample.ts
+++ b/source-code/core2/src/fullExample.ts
@@ -1,4 +1,4 @@
-import { createApp } from "./app/createApp.js"
+import { createInlang } from "./app/createInlang.js"
 import type { InlangConfig } from "./config/schema.js"
 import type {  MessageLintRule } from "./lint/api.js"
 import type { Plugin_Proposal_2 } from "./plugin/api.js"
@@ -77,7 +77,7 @@ const config = fs.readFile("./inlang.config.json")
 
 // 2. Create the app instance
 //    - env needs be created
-const inlang = createApp({
+const inlang = createInlang({
 	config,
 	env: { fs: undefined as any, import: undefined as any },
 })


### PR DESCRIPTION
## Problem 

"App" leads to confusion communication. 

For example, is the IDE-extension "the app" or the return of `createApp`? 

## Proposal 

1. Rename `createApp` to `createInlang`
2. Refer to the retutn value as "inlang instance", not "inlang app". 
