### PR TITLE
[api spec] use lint report function

### DIFF
--- a/source-code/core2/src/fullExample.ts
+++ b/source-code/core2/src/fullExample.ts
@@ -12,25 +12,20 @@ const missingMessage: MessageLintRule = {
 		de: "Fehlende Nachricht",
 	},
 	defaultLevel: "error",
-	type: "Message",
-	message: ({ message, inlang }) => {
+	message: ({ message, inlang, report }) => {
 		if (message.languageTag !== inlang.config.sourceLanguageTag) {
 			return
 		}
-		// TODO pain to make reports typesafe...
-		// - MessageLintReport has a lot of duplicate information
-		const reports = []
 		for (const languageTag of inlang.config.languageTags) {
 			const translation = inlang.messages.query.get({ where: { id: message.id, languageTag } })
 			if (!translation) {
-				reports.push({
+				report({
 					languageTag,
 					messageId: message.id,
 					content: `Message "${message.id}" is missing in language tag "${languageTag}".`,
 				})
 			}
 		}
-		return reports
 	},
 }
 

--- a/source-code/core2/src/lint/api.ts
+++ b/source-code/core2/src/lint/api.ts
@@ -13,16 +13,15 @@ export type LintRule = {
 	defaultLevel: "error" | "warn"
 }
 
-// TODO better "message" agnostic way for linting system?
-// - Trying to make the lint system "message" agnostic.
-//
 export type MessageLintRule = LintRule & {
-	type: "Message"
-	message: (args: {
-		message: Message
-		inlang: InlangApp
-	}) => MaybeArray<Omit<MessageLintReport, "ruleId" | "level" | "type">> | undefined | void
+	message: (args: { message: Message; inlang: InlangApp; report: ReportMessageLint }) => void
 }
+
+export type ReportMessageLint = (args: {
+	messageId: Message["id"]
+	languageTag: LanguageTag
+	content: LintReport["content"]
+}) => MessageLintReport
 
 export type LintReport = {
 	ruleId: LintRule["id"]
@@ -42,5 +41,3 @@ export class LintException extends Error {
 		this.name = "LintException"
 	}
 }
-
-type MaybeArray<T> = T | T[]


### PR DESCRIPTION
## Context

Follow up of https://github.com/inlang/inlang/pull/1149#discussion_r1270506548. 

## Observations 

The API becomes simpler and more agnostic:

#### 1. No manual "type": "Message" for a lint rule. 

If a message callback is provided, the lint rule is for a message. 

In the future, we can extend lint rules by other callbacks. 

#### 2. The report function makes "reports" a bit easier

No more `const result: LintReport` which lead to a lot of type issues. 


