### PR TITLE
[api spec] make lints translatable 

### DIFF
--- a/source-code/core2/src/fullExample.ts
+++ b/source-code/core2/src/fullExample.ts
@@ -22,7 +22,10 @@ const missingMessage: MessageLintRule = {
 				report({
 					languageTag,
 					messageId: message.id,
-					content: `Message "${message.id}" is missing in language tag "${languageTag}".`,
+					body: {
+						'en':`Message "${message.id}" is missing in language tag "${languageTag}".`,
+						'de':`Nachricht "${message.id}" fehlt für Sprachtag "${languageTag}".`,
+					}
 				})
 			}
 		}

--- a/source-code/core2/src/lint/api.ts
+++ b/source-code/core2/src/lint/api.ts
@@ -47,4 +47,4 @@ export class LintException extends Error {
  *
  * The language tag `en` is always required.
  */
-type TranslatedStrings = Record<string, string> & { en: string }
+type TranslatedStrings = Record<LanguageTag, string> & { en: string }

--- a/source-code/core2/src/lint/api.ts
+++ b/source-code/core2/src/lint/api.ts
@@ -4,7 +4,7 @@ import type { Message } from "../messages/schema.js"
 
 export type LintRule = {
 	id: `${string}.${string}`
-	displayName: Record<string, string>
+	displayName: TranslatedStrings
 	/**
 	 * The default level of the lint rule.
 	 *
@@ -20,13 +20,13 @@ export type MessageLintRule = LintRule & {
 export type ReportMessageLint = (args: {
 	messageId: Message["id"]
 	languageTag: LanguageTag
-	content: LintReport["content"]
+	body: LintReport["body"]
 }) => MessageLintReport
 
 export type LintReport = {
 	ruleId: LintRule["id"]
 	level: "error" | "warn"
-	content: string
+	body: TranslatedStrings
 }
 
 export type MessageLintReport = LintReport & {
@@ -41,3 +41,10 @@ export class LintException extends Error {
 		this.name = "LintException"
 	}
 }
+
+/**
+ * Translated strings for a given language tag.
+ *
+ * The language tag `en` is always required.
+ */
+type TranslatedStrings = Record<string, string> & { en: string }


### PR DESCRIPTION
## Problem 

Inlang apps like the IDE-extension and web editor can't show messages in the users language. 

## Proposal 

1. Make lint reports _optionally_ translatable
2. Always force language tag "en" to be provided as fallback. 


https://github.com/inlang/inlang/assets/35429197/bda0b105-ce23-4263-840b-f0be2a9d2f45


