### PR TITLE
[api-spec] query api draft nils

### DIFF
--- a/source-code/core2/src/messages/query.ts
+++ b/source-code/core2/src/messages/query.ts
@@ -1,14 +1,15 @@
 import { createInlang } from "../app/createInlang.js"
+import type { LanguageTag } from "../languageTag.js"
 import type { Message } from "./schema.js"
 
 type UniqueFilterType = {
-	id: string
-	languageTag: string
+	id: Message["id"]
+	languageTag: LanguageTag
 	//variant: string -> in the future
 }
 type FilterType = {
-	id?: string
-	languageTag?: string
+	id?: Message["id"]
+	languageTag?: LanguageTag
 	//variant?: string -> in the future
 }
 

--- a/source-code/core2/src/messages/query.ts
+++ b/source-code/core2/src/messages/query.ts
@@ -1,3 +1,4 @@
+import { createInlang } from "../app/createInlang.js"
 import type { Message } from "./schema.js"
 
 type UniqueFilterType = {
@@ -11,21 +12,67 @@ type FilterType = {
 	//variant?: string -> in the future
 }
 
-// inspiration: Prisma CRUD https://www.prisma.io/docs/concepts/components/prisma-client/crud
-export type MessagesQueryApi_1 = {
-	create: (message: Message) => Message
-	get: (where: UniqueFilterType) => Message
-	getMany: (where: FilterType) => Message[]
-	update: (where: UniqueFilterType, data: Message["pattern"]) => Message
-	delete: (where: UniqueFilterType) => Message
+type GetType = {
+	where: UniqueFilterType
 }
 
+type GetManyType = {
+	where: FilterType
+}
+
+type UpdateType = {
+	where: UniqueFilterType
+	pattern: Message["pattern"]
+}
+
+type UpsertType = {
+	where: UniqueFilterType
+	pattern: Message["pattern"]
+	message: Message
+}
+
+type DeleteType = {
+	where: FilterType
+}
+
+// inspiration: Prisma CRUD https://www.prisma.io/docs/concepts/components/prisma-client/crud
+export type MessagesQueryApi_1 = {
+	create: (args: Message) => Message
+	get: (args: GetType) => Message
+	getMany: (args: GetManyType) => Message[]
+	update: (args: UpdateType) => Message
+	upsert: (args: UpsertType) => Message
+	delete: (args: DeleteType) => Message
+}
+
+const inlang = createInlang({
+	configPath: "/hello/inlang.config.json",
+	env: { fs: undefined as any, import: undefined as any },
+})
+
 // example usage
-const message = inlang.messages.query.create({ id: "myMessageId", languageTag: "en", pattern: [{"type": "Text", value:  "Hello World" }]})
+const message = inlang.messages.query.create({
+	id: "myMessageId",
+	languageTag: "en",
+	pattern: [{ type: "Text", value: "Hello World" }],
+})
 
-const message = inlang.messages.query.get({ where: { id: "myMessageId", languageTag: "en" })
-const messages = inlang.messages.query.getMany({ where: { id: "myMessageId" })
+const message = inlang.messages.query.get({ where: { id: "myMessageId", languageTag: "en" } })
+const messages = inlang.messages.query.getMany({ where: { id: "myMessageId" } })
 
-const message = inlang.messages.query.update({ where: { id: "myMessageId", languageTag: "en" }, data: { pattern: [{"type": "Text", value:  "Hello World" }] } })
+const message = inlang.messages.query.update({
+	where: { id: "myMessageId", languageTag: "en" },
+	pattern: [{ type: "Text", value: "Hello World" }],
+})
+
+const message = inlang.messages.query.upsert({
+	where: { id: "myMessageId", languageTag: "en" },
+	pattern: [{ type: "Text", value: "Hello World" }],
+	message: {
+		id: "myMessageId",
+		languageTag: "en",
+		pattern: [{ type: "Text", value: "Hello World" }],
+	},
+})
 
 const message = inlang.messages.query.delete({ where: { id: "myMessageId", languageTag: "en" } })

--- a/source-code/core2/src/messages/query.ts
+++ b/source-code/core2/src/messages/query.ts
@@ -14,7 +14,6 @@ type FilterType = {
 
 // inspiration: Prisma CRUD https://www.prisma.io/docs/concepts/components/prisma-client/crud
 export type MessagesQueryApi_1 = {
-	create: (args: Message) => Message
 	get: (args: { where: UniqueFilterType }) => [Message, Error]
 	getMany: (args: { where: FilterType }) => [Message[], Error]
 	upsert: (args: Message) => [Message, Error]
@@ -28,8 +27,8 @@ const inlang = createInlang({
 	env: { fs: undefined as any, import: undefined as any },
 })
 
-// example usage
-const message1 = inlang.messages.query.create({
+// create
+const message1 = inlang.messages.query.upsert({
 	id: "myMessageId",
 	languageTag: "en",
 	pattern: [{ type: "Text", value: "Hello World" }],
@@ -38,10 +37,17 @@ const message1 = inlang.messages.query.create({
 const message2 = inlang.messages.query.get({ where: { id: "myMessageId", languageTag: "en" } })
 const messages = inlang.messages.query.getMany({ where: { id: "myMessageId" } })
 
-const message4 = inlang.messages.query.upsert({
-	id: "myMessageId",
-	languageTag: "en",
-	pattern: [{ type: "Text", value: "Hello World" }],
-})
+const message4 = inlang.messages.query.upsertMany([
+	{
+		id: "myMessageId",
+		languageTag: "en",
+		pattern: [{ type: "Text", value: "Hello World" }],
+	},
+	{
+		id: "otherMessageId",
+		languageTag: "en",
+		pattern: [{ type: "Text", value: "Hello World" }],
+	},
+])
 
 const message5 = inlang.messages.query.delete({ where: { id: "myMessageId", languageTag: "en" } })

--- a/source-code/core2/src/messages/query.ts
+++ b/source-code/core2/src/messages/query.ts
@@ -15,8 +15,11 @@ type FilterType = {
 
 // inspiration: Prisma CRUD https://www.prisma.io/docs/concepts/components/prisma-client/crud
 export type MessagesQueryApi_1 = {
+	create: (args: Message) => [Message, Error]
 	get: (args: { where: UniqueFilterType }) => [Message, Error]
 	getMany: (args: { where: FilterType }) => [Message[], Error]
+	update: (args: Message) => [Message, Error]
+	updateMany: (args: Message[]) => [Message[], Error]
 	upsert: (args: Message) => [Message, Error]
 	upsertMany: (args: Message[]) => [Message[], Error]
 	delete: (args: { where: UniqueFilterType }) => [Message, Error]
@@ -37,7 +40,20 @@ const message1 = inlang.messages.query.upsert({
 
 const message2 = inlang.messages.query.get({ where: { id: "myMessageId", languageTag: "en" } })
 const messages = inlang.messages.query.getMany({ where: { id: "myMessageId" } })
+const allMessages = inlang.messages.query.getMany({ where: {} })
 
+const message3 = inlang.messages.query.updateMany([
+	{
+		id: "myMessageId",
+		languageTag: "en",
+		pattern: [{ type: "Text", value: "Hello World" }],
+	},
+	{
+		id: "myMessageId",
+		languageTag: "en",
+		pattern: [{ type: "Text", value: "Hello World" }],
+	},
+])
 const message4 = inlang.messages.query.upsertMany([
 	{
 		id: "myMessageId",
@@ -45,7 +61,7 @@ const message4 = inlang.messages.query.upsertMany([
 		pattern: [{ type: "Text", value: "Hello World" }],
 	},
 	{
-		id: "otherMessageId",
+		id: "myMessageId",
 		languageTag: "en",
 		pattern: [{ type: "Text", value: "Hello World" }],
 	},

--- a/source-code/core2/src/messages/query.ts
+++ b/source-code/core2/src/messages/query.ts
@@ -19,3 +19,13 @@ export type MessagesQueryApi_1 = {
 	update: (where: UniqueFilterType, data: Message["pattern"]) => Message
 	delete: (where: UniqueFilterType) => Message
 }
+
+// example usage
+const message = inlang.messages.query.create({ id: "myMessageId", languageTag: "en", pattern: [{"type": "Text", value:  "Hello World" }]})
+
+const message = inlang.messages.query.get({ where: { id: "myMessageId", languageTag: "en" })
+const messages = inlang.messages.query.getMany({ where: { id: "myMessageId" })
+
+const message = inlang.messages.query.update({ where: { id: "myMessageId", languageTag: "en" }, data: { pattern: [{"type": "Text", value:  "Hello World" }] } })
+
+const message = inlang.messages.query.delete({ where: { id: "myMessageId", languageTag: "en" } })

--- a/source-code/core2/src/messages/query.ts
+++ b/source-code/core2/src/messages/query.ts
@@ -1,15 +1,21 @@
 import type { Message } from "./schema.js"
 
-// TODO
-// 1. Query builder?
-// 2. Filtering etc how?
-//
-// inspiration: Prisma CRUD https://www.prisma.io/docs/concepts/components/prisma-client/crud
-export type MessagesQueryApi_1 = {
-	create: (message: Message) => void
-	get: () => Message[]
-	update: () => void
-	delete: () => void
+type UniqueFilterType = {
+	id: string
+	languageTag: string
+	//variant: string -> in the future
+}
+type FilterType = {
+	id?: string
+	languageTag?: string
+	//variant?: string -> in the future
 }
 
-// query.
+// inspiration: Prisma CRUD https://www.prisma.io/docs/concepts/components/prisma-client/crud
+export type MessagesQueryApi_1 = {
+	create: (message: Message) => Message
+	get: (where: UniqueFilterType) => Message
+	getMany: (where: FilterType) => Message[]
+	update: (where: UniqueFilterType, data: Message["pattern"]) => Message
+	delete: (where: UniqueFilterType) => Message
+}

--- a/source-code/core2/src/messages/query.ts
+++ b/source-code/core2/src/messages/query.ts
@@ -17,8 +17,6 @@ export type MessagesQueryApi_1 = {
 	create: (args: Message) => Message
 	get: (args: { where: UniqueFilterType }) => [Message, Error]
 	getMany: (args: { where: FilterType }) => [Message[], Error]
-	update: (args: Message) => Message
-	updateMany: (args: Message[]) => [Message[], Error]
 	upsert: (args: Message) => [Message, Error]
 	upsertMany: (args: Message[]) => [Message[], Error]
 	delete: (args: { where: UniqueFilterType }) => [Message, Error]
@@ -40,19 +38,10 @@ const message1 = inlang.messages.query.create({
 const message2 = inlang.messages.query.get({ where: { id: "myMessageId", languageTag: "en" } })
 const messages = inlang.messages.query.getMany({ where: { id: "myMessageId" } })
 
-const message3 = inlang.messages.query.update({
-	where: { id: "myMessageId", languageTag: "en" },
-	pattern: [{ type: "Text", value: "Hello World" }],
-})
-
 const message4 = inlang.messages.query.upsert({
-	where: { id: "myMessageId", languageTag: "en" },
+	id: "myMessageId",
+	languageTag: "en",
 	pattern: [{ type: "Text", value: "Hello World" }],
-	message: {
-		id: "myMessageId",
-		languageTag: "en",
-		pattern: [{ type: "Text", value: "Hello World" }],
-	},
 })
 
 const message5 = inlang.messages.query.delete({ where: { id: "myMessageId", languageTag: "en" } })

--- a/source-code/core2/src/messages/query.ts
+++ b/source-code/core2/src/messages/query.ts
@@ -15,15 +15,14 @@ type FilterType = {
 // inspiration: Prisma CRUD https://www.prisma.io/docs/concepts/components/prisma-client/crud
 export type MessagesQueryApi_1 = {
 	create: (args: Message) => Message
-	get: (args: { where: UniqueFilterType }) => Message
-	getMany: (args: { where: FilterType }) => Message[]
-	update: (args: { where: UniqueFilterType; pattern: Message["pattern"] }) => Message
-	upsert: (args: {
-		where: UniqueFilterType
-		pattern: Message["pattern"]
-		message: Message
-	}) => Message
-	delete: (args: { where: UniqueFilterType }) => Message
+	get: (args: { where: UniqueFilterType }) => [Message, Error]
+	getMany: (args: { where: FilterType }) => [Message[], Error]
+	update: (args: Message) => Message
+	updateMany: (args: Message[]) => [Message[], Error]
+	upsert: (args: Message) => [Message, Error]
+	upsertMany: (args: Message[]) => [Message[], Error]
+	delete: (args: { where: UniqueFilterType }) => [Message, Error]
+	deleteMany: (args: { where: FilterType }) => [Message[], Error]
 }
 
 const inlang = createInlang({

--- a/source-code/core2/src/messages/query.ts
+++ b/source-code/core2/src/messages/query.ts
@@ -12,37 +12,18 @@ type FilterType = {
 	//variant?: string -> in the future
 }
 
-type GetType = {
-	where: UniqueFilterType
-}
-
-type GetManyType = {
-	where: FilterType
-}
-
-type UpdateType = {
-	where: UniqueFilterType
-	pattern: Message["pattern"]
-}
-
-type UpsertType = {
-	where: UniqueFilterType
-	pattern: Message["pattern"]
-	message: Message
-}
-
-type DeleteType = {
-	where: FilterType
-}
-
 // inspiration: Prisma CRUD https://www.prisma.io/docs/concepts/components/prisma-client/crud
 export type MessagesQueryApi_1 = {
 	create: (args: Message) => Message
-	get: (args: GetType) => Message
-	getMany: (args: GetManyType) => Message[]
-	update: (args: UpdateType) => Message
-	upsert: (args: UpsertType) => Message
-	delete: (args: DeleteType) => Message
+	get: (args: { where: UniqueFilterType }) => Message
+	getMany: (args: { where: FilterType }) => Message[]
+	update: (args: { where: UniqueFilterType; pattern: Message["pattern"] }) => Message
+	upsert: (args: {
+		where: UniqueFilterType
+		pattern: Message["pattern"]
+		message: Message
+	}) => Message
+	delete: (args: { where: UniqueFilterType }) => Message
 }
 
 const inlang = createInlang({
@@ -51,21 +32,21 @@ const inlang = createInlang({
 })
 
 // example usage
-const message = inlang.messages.query.create({
+const message1 = inlang.messages.query.create({
 	id: "myMessageId",
 	languageTag: "en",
 	pattern: [{ type: "Text", value: "Hello World" }],
 })
 
-const message = inlang.messages.query.get({ where: { id: "myMessageId", languageTag: "en" } })
+const message2 = inlang.messages.query.get({ where: { id: "myMessageId", languageTag: "en" } })
 const messages = inlang.messages.query.getMany({ where: { id: "myMessageId" } })
 
-const message = inlang.messages.query.update({
+const message3 = inlang.messages.query.update({
 	where: { id: "myMessageId", languageTag: "en" },
 	pattern: [{ type: "Text", value: "Hello World" }],
 })
 
-const message = inlang.messages.query.upsert({
+const message4 = inlang.messages.query.upsert({
 	where: { id: "myMessageId", languageTag: "en" },
 	pattern: [{ type: "Text", value: "Hello World" }],
 	message: {
@@ -75,4 +56,4 @@ const message = inlang.messages.query.upsert({
 	},
 })
 
-const message = inlang.messages.query.delete({ where: { id: "myMessageId", languageTag: "en" } })
+const message5 = inlang.messages.query.delete({ where: { id: "myMessageId", languageTag: "en" } })


### PR DESCRIPTION
It's a draft.

I want to keep it as easy as possible:
Because there will be confusion with return types for get, I added `getMany`. The rest stays straightforward.

I also added Message as return type of `get`, `update`, `create` and `delete`. Was inspired by prisma. Helps with framework specific data handling.

Current:

```ts
export type MessagesQueryApi = {
	create: (args: Message) => [Message, Error]
	get: (args: { where: UniqueFilterType }) => [Message, Error]
	getMany: (args: { where: FilterType }) => [Message[], Error]
	update: (args: Message) => [Message, Error]
	updateMany: (args: Message[]) => [Message[], Error]
	upsert: (args: Message) => [Message, Error]
	upsertMany: (args: Message[]) => [Message[], Error]
	delete: (args: { where: UniqueFilterType }) => [Message, Error]
	deleteMany: (args: { where: FilterType }) => [Message[], Error]
}
```