### PR TITLE
stricter lint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,6 +28,38 @@
 		"unicorn/prefer-node-protocol": "error",
 		"@typescript-eslint/ban-ts-comment": "off",
 		"@typescript-eslint/no-explicit-any": "off",
+		"no-console": [
+			"error",
+			{
+				// allow everything except `console.log`
+				"allow": [
+					"debug",
+					"error",
+					"info",
+					"warn",
+					"dir",
+					"dirxml",
+					"table",
+					"trace",
+					"group",
+					"groupCollapsed",
+					"groupEnd",
+					"clear",
+					"count",
+					"countReset",
+					"assert",
+					"profile",
+					"profileEnd",
+					"time",
+					"timeLog",
+					"timeEnd",
+					"timeStamp",
+					"context",
+					"createTask",
+					"memory"
+				]
+			}
+		],
 		// conflicts with SolidJS
 		"@typescript-eslint/no-non-null-assertion": "off"
 	}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
 
       - name: install node
         uses: actions/setup-node@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,4 +46,4 @@ jobs:
         uses: actions-js/push@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          message: 'chore: autofix lint issues'
+          message: "chore: autofix lint issues"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: 18
           cache: "npm"
 
-      - run: npm install --no-save
+      - run: npm install
 
       - name: run formatters
         run: npm run format:fix

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,8 +22,11 @@ jobs:
 
       - run: npm install --no-save
 
+      - name: run formatters
+        run: npm run format:fix
+
       - name: run linters
-        run: npm run lint
+        run: npm run lint:fix
 
       - name: run link checker
         uses: lycheeverse/lychee-action@v1.8.0
@@ -35,3 +38,9 @@ jobs:
 
       - name: run inlang lint
         run: npx @inlang/cli@latest lint
+
+      - name: commit & push changes
+        uses: actions-js/push@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          message: 'chore: autofix lint issues'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,5 +25,8 @@
 	},
 	"[yaml]": {
 		"editor.defaultFormatter": "redhat.vscode-yaml"
+	},
+	"[jsonc]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
 	}
 }

--- a/source-code-git/client/src/raw/tests/hashBlob.test.ts
+++ b/source-code-git/client/src/raw/tests/hashBlob.test.ts
@@ -27,10 +27,10 @@ minimisted(async function ({ _: [command, ...args], ...opts }) {
     }
   }
   cmd += \`.\${command}(\${args.map(x => \`'\${x}'\`).join(', ')})\`
-  console.info(cmd)
+  console.log(cmd)
   let result = await repo[command](...args)
   if (result === undefined) return
-  console.info(JSON.stringify(result, null, 2))
+  console.log(JSON.stringify(result, null, 2))
 })
 `
 

--- a/source-code-git/client/src/raw/tests/hashBlob.test.ts
+++ b/source-code-git/client/src/raw/tests/hashBlob.test.ts
@@ -27,10 +27,10 @@ minimisted(async function ({ _: [command, ...args], ...opts }) {
     }
   }
   cmd += \`.\${command}(\${args.map(x => \`'\${x}'\`).join(', ')})\`
-  console.log(cmd)
+  console.info(cmd)
   let result = await repo[command](...args)
   if (result === undefined) return
-  console.log(JSON.stringify(result, null, 2))
+  console.info(JSON.stringify(result, null, 2))
 })
 `
 

--- a/source-code-git/client/src/raw/tests/readBlob.test.ts
+++ b/source-code-git/client/src/raw/tests/readBlob.test.ts
@@ -35,10 +35,10 @@ describe("readBlob", () => {
       "#!/usr/bin/env node
       const minimisted = require('minimisted')
       const git = require('.')
-      
+
       // This really isn't much of a CLI. It's mostly for testing.
       // But it's very versatile and works surprisingly well.
-      
+
       minimisted(async function ({ _: [command, ...args], ...opts }) {
         const dir = process.cwd()
         const repo = git(dir)
@@ -54,10 +54,10 @@ describe("readBlob", () => {
           }
         }
         cmd += \`.\${command}(\${args.map(x => \`'\${x}'\`).join(', ')})\`
-        console.log(cmd)
+        console.info(cmd)
         let result = await repo[command](...args)
         if (result === undefined) return
-        console.log(JSON.stringify(result, null, 2))
+        console.info(JSON.stringify(result, null, 2))
       })
       "
     `)

--- a/source-code-git/client/src/raw/tests/readBlob.test.ts
+++ b/source-code-git/client/src/raw/tests/readBlob.test.ts
@@ -54,10 +54,10 @@ describe("readBlob", () => {
           }
         }
         cmd += \`.\${command}(\${args.map(x => \`'\${x}'\`).join(', ')})\`
-        console.info(cmd)
+        console.log(cmd)
         let result = await repo[command](...args)
         if (result === undefined) return
-        console.info(JSON.stringify(result, null, 2))
+        console.log(JSON.stringify(result, null, 2))
       })
       "
     `)

--- a/source-code-git/client/src/raw/tests/readObject.test.ts
+++ b/source-code-git/client/src/raw/tests/readObject.test.ts
@@ -49,7 +49,7 @@ describe("readObject", () => {
           },
           "gpgsig": "-----BEGIN PGP SIGNATURE-----
       Version: GnuPG v1
-      
+
       iQIcBAABAgAGBQJZjhboAAoJEJYJuKWSi6a5V5UP/040SfemJ13PRBXst2eB59gs
       3hPx29DRKBhFtvk+uS+8523/hUfry2oeWWd6YRkcnkxxAUtBnfzVkI9AgRIc1NTM
       h5XtLMQubCAKw8JWvVvoXETzwVAODmdmvC4WSQCLu+opoe6/W7RvkrTD0pbkwH4E
@@ -169,10 +169,10 @@ describe("readObject", () => {
       "#!/usr/bin/env node
       const minimisted = require('minimisted')
       const git = require('.')
-      
+
       // This really isn't much of a CLI. It's mostly for testing.
       // But it's very versatile and works surprisingly well.
-      
+
       minimisted(async function ({ _: [command, ...args], ...opts }) {
         const dir = process.cwd()
         const repo = git(dir)
@@ -188,10 +188,10 @@ describe("readObject", () => {
           }
         }
         cmd += \`.\${command}(\${args.map(x => \`'\${x}'\`).join(', ')})\`
-        console.log(cmd)
+        console.info(cmd)
         let result = await repo[command](...args)
         if (result === undefined) return
-        console.log(JSON.stringify(result, null, 2))
+        console.info(JSON.stringify(result, null, 2))
       })
       "
     `)

--- a/source-code-git/client/src/raw/tests/readObject.test.ts
+++ b/source-code-git/client/src/raw/tests/readObject.test.ts
@@ -188,10 +188,10 @@ describe("readObject", () => {
           }
         }
         cmd += \`.\${command}(\${args.map(x => \`'\${x}'\`).join(', ')})\`
-        console.info(cmd)
+        console.log(cmd)
         let result = await repo[command](...args)
         if (result === undefined) return
-        console.info(JSON.stringify(result, null, 2))
+        console.log(JSON.stringify(result, null, 2))
       })
       "
     `)

--- a/source-code-git/client/src/raw/tests/writeBlob.test.ts
+++ b/source-code-git/client/src/raw/tests/writeBlob.test.ts
@@ -46,10 +46,10 @@ minimisted(async function ({ _: [command, ...args], ...opts }) {
     }
   }
   cmd += \`.\${command}(\${args.map(x => \`'\${x}'\`).join(', ')})\`
-  console.info(cmd)
+  console.log(cmd)
   let result = await repo[command](...args)
   if (result === undefined) return
-  console.info(JSON.stringify(result, null, 2))
+  console.log(JSON.stringify(result, null, 2))
 })
 `,
 				"utf8",

--- a/source-code-git/client/src/raw/tests/writeBlob.test.ts
+++ b/source-code-git/client/src/raw/tests/writeBlob.test.ts
@@ -46,10 +46,10 @@ minimisted(async function ({ _: [command, ...args], ...opts }) {
     }
   }
   cmd += \`.\${command}(\${args.map(x => \`'\${x}'\`).join(', ')})\`
-  console.log(cmd)
+  console.info(cmd)
   let result = await repo[command](...args)
   if (result === undefined) return
-  console.log(JSON.stringify(result, null, 2))
+  console.info(JSON.stringify(result, null, 2))
 })
 `,
 				"utf8",

--- a/source-code-git/client/src/raw/tests/writeObject.test.ts
+++ b/source-code-git/client/src/raw/tests/writeObject.test.ts
@@ -129,10 +129,10 @@ minimisted(async function ({ _: [command, ...args], ...opts }) {
     }
   }
   cmd += \`.\${command}(\${args.map(x => \`'\${x}'\`).join(', ')})\`
-  console.info(cmd)
+  console.log(cmd)
   let result = await repo[command](...args)
   if (result === undefined) return
-  console.info(JSON.stringify(result, null, 2))
+  console.log(JSON.stringify(result, null, 2))
 })
 `,
 			format: "parsed",

--- a/source-code-git/client/src/raw/tests/writeObject.test.ts
+++ b/source-code-git/client/src/raw/tests/writeObject.test.ts
@@ -129,10 +129,10 @@ minimisted(async function ({ _: [command, ...args], ...opts }) {
     }
   }
   cmd += \`.\${command}(\${args.map(x => \`'\${x}'\`).join(', ')})\`
-  console.log(cmd)
+  console.info(cmd)
   let result = await repo[command](...args)
   if (result === undefined) return
-  console.log(JSON.stringify(result, null, 2))
+  console.info(JSON.stringify(result, null, 2))
 })
 `,
 			format: "parsed",

--- a/source-code/cli/build.js
+++ b/source-code/cli/build.js
@@ -27,7 +27,7 @@ const ctx = await context({
 
 if (isProduction === false) {
 	await ctx.watch()
-	console.log("Watching for changes...")
+	console.info("Watching for changes...")
 } else {
 	await ctx.rebuild()
 	await ctx.dispose()

--- a/source-code/cli/src/utilities/getSupportedLibrary.test.ts
+++ b/source-code/cli/src/utilities/getSupportedLibrary.test.ts
@@ -2,7 +2,6 @@ import { expect, test } from "vitest"
 import { getSupportedLibrary } from "./getSupportedLibrary.js"
 
 // Mock console.info to suppress logs during testing
-// eslint-disable-next-line no-console
 console.info = () => undefined
 
 const testData = [

--- a/source-code/cli/src/utilities/getSupportedLibrary.test.ts
+++ b/source-code/cli/src/utilities/getSupportedLibrary.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from "vitest"
 import { getSupportedLibrary } from "./getSupportedLibrary.js"
 
-// Mock console.log to suppress logs during testing
-console.log = () => undefined
+// Mock console.info to suppress logs during testing
+// eslint-disable-next-line no-console
+console.info = () => undefined
 
 const testData = [
 	{

--- a/source-code/core/src/config/ideExtension/zodSchema.test.ts
+++ b/source-code/core/src/config/ideExtension/zodSchema.test.ts
@@ -25,7 +25,7 @@ it("should validate a valid config object", () => {
 		extractMessageOptions: [
 			{
 				callback: (messageId: string, selection: string) =>
-					`console.log(\`${messageId}: ${selection}\`)`,
+					`console.info(\`${messageId}: ${selection}\`)`,
 			},
 		],
 	}
@@ -47,7 +47,7 @@ it("should throw an error for a config object with invalid extractMessageOptions
 		extractMessageOptions: [
 			{
 				callback: (messageId: string, selection: string) =>
-					`console.log(\`${messageId}: ${selection}\`)`,
+					`console.info(\`${messageId}: ${selection}\`)`,
 			},
 			{ callback: {} },
 		],
@@ -64,7 +64,7 @@ it("should throw an error for a config object with invalid messageReferenceMatch
 		extractMessageOptions: [
 			{
 				callback: (messageId: string, selection: string) =>
-					`console.log(\`${messageId}: ${selection}\`)`,
+					`console.info(\`${messageId}: ${selection}\`)`,
 			},
 		],
 	}

--- a/source-code/core/src/lint/output.ts
+++ b/source-code/core/src/lint/output.ts
@@ -48,5 +48,6 @@ export const printReport = (
 
 	const { id, level, message } = report
 	const method = methodOverride ?? (level === "error" ? "error" : "warn")
+	// eslint-disable-next-line no-console
 	console[method](`[${level}] (${id}) ${message}`)
 }

--- a/source-code/env-variables/build.ts
+++ b/source-code/env-variables/build.ts
@@ -18,14 +18,14 @@ config({ path: rootEnvFilePath, override: true })
 const [, errors] = validateEnvVariables({ forProduction: false })
 
 if (errors) {
-	console.log("💡 Some env variables are not defined. Fetching public env variables remotely...")
-	console.log(errors)
+	console.error("💡 Some env variables are not defined. Fetching public env variables remotely...")
+	console.error(errors)
 	// some required env variables are missing. fetch public env variables from the server
 	await fetchPublicEnv()
 	const [, stillErrors] = validateEnvVariables({ forProduction: false })
 	if (stillErrors) {
-		console.log("🚨 Some env variables are still not defined, even after fetching. Exiting...")
-		console.log(stillErrors)
+		console.error("🚨 Some env variables are still not defined, even after fetching. Exiting...")
+		console.error(stillErrors)
 		process.exit(1)
 	}
 }

--- a/source-code/env-variables/src/build/fetchPublicEnv.ts
+++ b/source-code/env-variables/src/build/fetchPublicEnv.ts
@@ -35,17 +35,17 @@ export async function fetchPublicEnv() {
 			)
 			const [, errors] = validateEnvVariables({ forProduction: false })
 			if (errors === undefined) {
-				console.log("✅ Fetched public env variables remotely.")
+				console.info("✅ Fetched public env variables remotely.")
 			} else {
 				console.warn(
 					"⚠️ Fetched public env variables remotely but some are missing or invalid. Contact the maintainers.",
 				)
-				console.log(errors)
+				console.error(errors)
 			}
 		} else {
-			console.log("❌ Failed to fetch public env variables remotely. ", data.messages)
+			console.error("❌ Failed to fetch public env variables remotely. ", data.messages)
 		}
 	} catch (error) {
-		console.log("❌ Failed to fetch public env variables remotely. ", error)
+		console.error("❌ Failed to fetch public env variables remotely. ", error)
 	}
 }

--- a/source-code/ide-extension/src/actions/extractMessage.ts
+++ b/source-code/ide-extension/src/actions/extractMessage.ts
@@ -25,7 +25,7 @@ export class ExtractMessage implements vscode.CodeActionProvider {
 	}
 
 	public async resolveCodeAction(): Promise<vscode.CodeAction> {
-		console.log("code action resolved")
+		console.info("code action resolved")
 		telemetry.capture({
 			event: "IDE-EXTENSION code action resolved",
 			properties: { name: "extract message" },

--- a/source-code/ide-extension/src/diagnostics/linterDiagnostics.ts
+++ b/source-code/ide-extension/src/diagnostics/linterDiagnostics.ts
@@ -22,7 +22,7 @@ export async function linterDiagnostics(args: { context: vscode.ExtensionContext
 		const [resourcesWithLints, errors] = await lint({ resources, config: state().config })
 
 		if (errors) {
-			console.log(errors)
+			console.error(errors)
 		}
 
 		// Use `getLintReports` to get lint reports

--- a/source-code/ide-extension/src/main.ts
+++ b/source-code/ide-extension/src/main.ts
@@ -74,7 +74,7 @@ async function main(args: { context: vscode.ExtensionContext }): Promise<void> {
 		if (!_workspaceFolder) {
 			console.warn("No workspace folder found.")
 		} else {
-			console.log("Creating inlang.config.js file.")
+			console.info("Creating inlang.config.js file.")
 			await createInlangConfigFile({ workspaceFolder: _workspaceFolder })
 		}
 		return

--- a/source-code/ide-extension/src/utilities/settings/getUserId.ts
+++ b/source-code/ide-extension/src/utilities/settings/getUserId.ts
@@ -7,7 +7,7 @@ import { getSetting, updateSetting } from "./index.js"
  *
  * @example
  * const userId = await getUserId()
- * console.log(userId) // 123e4567-e89b-12d3-a456-426614174000
+ * console.info(userId) // 123e4567-e89b-12d3-a456-426614174000
  */
 export async function getUserId() {
 	const persistedId = await getPersistedId()

--- a/source-code/plugins/i18next/src/ideExtension/messageReferenceMatchers.typescript.ts
+++ b/source-code/plugins/i18next/src/ideExtension/messageReferenceMatchers.typescript.ts
@@ -15,7 +15,7 @@ import {
 } from "typescript"
 
 export function recursive(node: Node, result: MessageReferenceMatch[]) {
-	// console.log(node.kind, SyntaxKind[node.kind])
+	// console.debug(node.kind, SyntaxKind[node.kind])
 	switch (node.kind) {
 		// regular function call matching e.g. t("some-id")
 		case SyntaxKind.CallExpression: {

--- a/source-code/rpc/src/functions/generateConfigFile.test.ts
+++ b/source-code/rpc/src/functions/generateConfigFile.test.ts
@@ -19,7 +19,7 @@ describe.skip("generating config files", () => {
 			})
 			if (exception) {
 				console.error(exception)
-				console.log(file)
+				console.error(file)
 			}
 			expect(exception).toBeUndefined()
 		},
@@ -44,7 +44,7 @@ describe.skip("generating config files", () => {
 			})
 			if (exception) {
 				console.error(exception)
-				console.log(file)
+				console.error(file)
 			}
 			expect(exception).toBeUndefined()
 		},

--- a/source-code/sdk-js-plugin/src/ideExtension/messageReferenceMatchers.test.ts
+++ b/source-code/sdk-js-plugin/src/ideExtension/messageReferenceMatchers.test.ts
@@ -52,7 +52,7 @@ describe("tFunction", () => {
     <p>{$i("yes')}</p>
     `
 		const matches = parse(sourceCode)
-		console.log(matches)
+		console.info(matches)
 		expect(matches).toHaveLength(0)
 	})
 

--- a/source-code/sdk-js/src/adapter-sveltekit/ast-transforms/+layout.svelte.test.ts
+++ b/source-code/sdk-js/src/adapter-sveltekit/ast-transforms/+layout.svelte.test.ts
@@ -405,18 +405,18 @@ describe.skip("transformLayoutSvelte", () => {
 
 		describe("root=false", () => {
 			it("is a proxy for transformSvelte", async () => {
-				const config = initTransformConfig()
-				const input = dedent`
-					<script>
-						import { language } from '@inlang/sdk-js'
-						export let data
-					</script>
+				// const config = initTransformConfig()
+				// const input = dedent`
+				// 	<script>
+				// 		import { language } from '@inlang/sdk-js'
+				// 		export let data
+				// 	</script>
 
-					<h1>Hello {data.name}!</h1>
+				// 	<h1>Hello {data.name}!</h1>
 
-					{language.toUpperCase()}
-				`
-				const transformed = transformLayoutSvelte("", config, input, false)
+				// 	{language.toUpperCase()}
+				// `
+				// const transformed = transformLayoutSvelte("", config, input, false)
 				// expect(transformed).toMatch(transformSvelte(config, input))
 			})
 		})

--- a/source-code/sdk-js/src/adapter-sveltekit/ast-transforms/hooks.server.js.test.ts
+++ b/source-code/sdk-js/src/adapter-sveltekit/ast-transforms/hooks.server.js.test.ts
@@ -184,7 +184,7 @@ describe("transformHooksServerJs", () => {
 					import { i } from '@inlang/sdk-js'
 
 					export const handle = ({ event, resolve }) => {
-						console.log(i('hi'))
+						console.info(i('hi'))
 						return resolve(event)
 					}
 			`,
@@ -197,7 +197,7 @@ describe("transformHooksServerJs", () => {
 				    excludedRoutes: [],
 				    getLanguage: () => undefined,
 				}).use(({ event, resolve }, { i }) => {
-				    console.log(i('hi'));
+				    console.info(i('hi'));
 				    return resolve(event);
 				});"
 			`)

--- a/source-code/sdk-js/src/adapter-sveltekit/examples/test-app/src/routes/[lang]/+layout.svelte
+++ b/source-code/sdk-js/src/adapter-sveltekit/examples/test-app/src/routes/[lang]/+layout.svelte
@@ -3,9 +3,8 @@
 	import { language, languages } from "@inlang/sdk-js"
 	export let data
 
-	$: console.log(1, data.language);
-	$: console.log(2, language);
-	$: console.log(3, $navigating);
+	$: console.info(2, language);
+	$: console.info(3, $navigating);
 </script>
 
 {languages}

--- a/source-code/server/src/main.ts
+++ b/source-code/server/src/main.ts
@@ -60,7 +60,7 @@ app.use(websiteRouter)
 
 const port = process.env.PORT ?? 3000
 app.listen(port)
-console.log(`Server running at http://localhost:${port}/`)
+console.info(`Server running at http://localhost:${port}/`)
 
 // log to sentry
 if (isProduction) {

--- a/source-code/starters/inlang-nextjs/tsconfig.json
+++ b/source-code/starters/inlang-nextjs/tsconfig.json
@@ -1,28 +1,28 @@
 {
-  "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "preserve",
-    "incremental": true,
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
-    "paths": {
-      "@/*": ["./*"]
-    }
-  },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+	"compilerOptions": {
+		"target": "es5",
+		"lib": ["dom", "dom.iterable", "esnext"],
+		"allowJs": true,
+		"skipLibCheck": true,
+		"strict": true,
+		"forceConsistentCasingInFileNames": true,
+		"noEmit": true,
+		"esModuleInterop": true,
+		"module": "esnext",
+		"moduleResolution": "node",
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"jsx": "preserve",
+		"incremental": true,
+		"plugins": [
+			{
+				"name": "next"
+			}
+		],
+		"paths": {
+			"@/*": ["./*"]
+		}
+	},
+	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "**/*.js"],
+	"exclude": ["node_modules"]
 }

--- a/source-code/starters/inlang-svelte/src/routes/[lang]/+layout.svelte
+++ b/source-code/starters/inlang-svelte/src/routes/[lang]/+layout.svelte
@@ -3,9 +3,9 @@
 	import { language, languages } from "@inlang/sdk-js"
 	export let data
 
-	$: console.log(1, data.language);
-	$: console.log(2, language);
-	$: console.log(3, $navigating);
+	$: console.info(1, data.language);
+	$: console.info(2, language);
+	$: console.info(3, $navigating);
 </script>
 
 {languages}

--- a/source-code/website/src/pages/Layout.tsx
+++ b/source-code/website/src/pages/Layout.tsx
@@ -414,8 +414,7 @@ function LanguagePicker() {
 		},
 	]
 
-	const handleSwitchTransltion = (language: { code: string; name: string }) => {
-		console.log("path", currentPageContext.urlParsed.pathname)
+	const handleSwitchTranslation = (language: { code: string; name: string }) => {
 		window.history.pushState(
 			{},
 			"",
@@ -443,7 +442,7 @@ function LanguagePicker() {
 									prop:type="checkbox"
 									// @ts-ignore
 									checked={locale() === language.code}
-									onClick={() => handleSwitchTransltion(language)}
+									onClick={() => handleSwitchTranslation(language)}
 								>
 									{language.name}
 									<p class="opacity-50" slot="suffix">

--- a/source-code/website/src/pages/editor/@host/@owner/@repository/State.tsx
+++ b/source-code/website/src/pages/editor/@host/@owner/@repository/State.tsx
@@ -843,7 +843,7 @@ async function readResources(config: InlangConfig) {
 
 	const [lintedResources] = await lint({ config, resources })
 	// const allLints = getLintReports(lintedResources ? lintedResources : ([] as LintedResource[]))
-	// console.log(allLints)
+	// console.info(allLints)
 	return lintedResources
 }
 

--- a/source-code/website/src/pages/editor/@host/@owner/@repository/components/PatternEditorTipTap.tsx
+++ b/source-code/website/src/pages/editor/@host/@owner/@repository/components/PatternEditorTipTap.tsx
@@ -25,7 +25,7 @@ export const TipTapEditor = (props: {
 	createEffect(() => {
 		if (editor) {
 			const json = useEditorJSON(() => editor())
-			console.log(json())
+			console.debug(json())
 		}
 	})
 

--- a/source-code/website/src/services/markdown/src/nodes/Heading.tsx
+++ b/source-code/website/src/services/markdown/src/nodes/Heading.tsx
@@ -105,8 +105,6 @@ const CopyWrapper = (props: { children: JSXElement }) => {
 								.replace(/-$/, "")
 								.toLowerCase() as string)
 
-					console.log(headlineText)
-
 					const link =
 						document.location.protocol +
 						"//" +

--- a/source-code/website/src/services/markdown/src/tags/BadgeGenerator.tsx
+++ b/source-code/website/src/services/markdown/src/tags/BadgeGenerator.tsx
@@ -7,7 +7,6 @@ export function BadgeGenerator() {
 
 	const getBadge = (url: string) => {
 		const repo = url.split("github.com/")[1]
-		console.log(repo)
 		if (repo) {
 			return `[![translation badge](https://inlang.com/badge?url=github.com/${repo})](https://inlang.com/editor/github.com/${repo}?ref=badge)`
 		} else {

--- a/source-code/website/tailwind.config.cjs
+++ b/source-code/website/tailwind.config.cjs
@@ -144,6 +144,6 @@ function usedClassWithDynamicColor() {
 	}
 	// filter duplicates
 	// result = [...new Set(result)]
-	// console.log("whitelisted the following dynamic color classes for tailwind css:", result)
+	// console.info("whitelisted the following dynamic color classes for tailwind css:", result)
 	return result
 }


### PR DESCRIPTION
closes #1168

 - `console.log` is now a lint error
 - the `lint` CI actions will now
    - run `npm i` and modifies the `package_lock.json` file if not up2date
    - auto-fix lint issues
    - format the whole code base
    - commit all changes
