### PR TITLE
fix: exclude meta tags from not being loaded

### DIFF
--- a/source-code/website/src/pages/Layout.tsx
+++ b/source-code/website/src/pages/Layout.tsx
@@ -16,6 +16,7 @@ import { SectionLayout } from "./index/components/sectionLayout.jsx"
 import { defaultLanguage, extractLocale } from "@src/renderer/_default.page.route.js"
 import { useI18n } from "@solid-primitives/i18n"
 import { NewsletterForm } from "@src/components/NewsletterForm.jsx"
+import { localesLoaded } from "@src/renderer/Root.jsx"
 
 /**
  * Ensure that all elements use the same margins.
@@ -45,16 +46,18 @@ export function Layout(props: { children: JSXElement }) {
 
 export const LandingPageLayout = (props: { children: JSXElement; landingpage?: boolean }) => {
 	return (
-		<div class="flex flex-col min-h-screen">
-			<Header landingpage={props.landingpage} />
-			{/* the outer div is growing to occupy the entire height and thereby
+		<Show when={localesLoaded()}>
+			<div class="flex flex-col min-h-screen">
+				<Header landingpage={props.landingpage} />
+				{/* the outer div is growing to occupy the entire height and thereby
 			push the footer to the bottom */}
-			<div class={"grow flex flex-col "}>
-				{/* the children are wrapped in a div to avoid flex and grow being applied to them from the outer div */}
-				{props.children}
+				<div class={"grow flex flex-col "}>
+					{/* the children are wrapped in a div to avoid flex and grow being applied to them from the outer div */}
+					{props.children}
+				</div>
+				<Footer isLandingPage />
 			</div>
-			<Footer isLandingPage />
-		</div>
+		</Show>
 	)
 }
 

--- a/source-code/website/src/renderer/Root.tsx
+++ b/source-code/website/src/renderer/Root.tsx
@@ -1,12 +1,4 @@
-import {
-	Accessor,
-	Component,
-	createEffect,
-	createSignal,
-	ErrorBoundary,
-	onMount,
-	Show,
-} from "solid-js"
+import { Accessor, Component, createEffect, createSignal, ErrorBoundary, onMount } from "solid-js"
 import type { PageContextRenderer } from "./types.js"
 import { Dynamic } from "solid-js/web"
 import { LocalStorageProvider } from "@src/services/local-storage/index.js"
@@ -17,6 +9,9 @@ import { createI18nContext } from "@solid-primitives/i18n"
 export type RootProps = Accessor<{
 	pageContext: PageContextRenderer
 }>
+
+// let the page know that the locales are loaded
+export const [localesLoaded, setLocalesLoaded] = createSignal(false)
 
 // get translation files and put it in context provider
 const [response] = await rpc.getLangResources()
@@ -51,18 +46,15 @@ function RootWithProviders(props: {
 	locale: string
 }) {
 	const [, { locale }] = useI18n()
-	const [isLoaded, setIsLoaded] = createSignal(false)
 
 	onMount(() => {
 		locale(props.locale)
-		setIsLoaded(true)
+		setLocalesLoaded(true)
 	})
 
 	return (
 		// <div>Hallo Welt</div>
-		<Show when={isLoaded()}>
-			<Dynamic component={props.page} {...props.pageProps} />
-		</Show>
+		<Dynamic component={props.page} {...props.pageProps} />
 	)
 }
 


### PR DESCRIPTION
fixed the issue that loading the locales prevented the meta tags from being loaded directly, which is necessary to let search engines read our SEO content.

Todo:
- Fix error in /editor page that appears because of the change in Root