### PR TITLE
CLI: Fix sdk-js-plugin getting updated to "0"

### DIFF
--- a/source-code/cli/src/commands/config/update.ts
+++ b/source-code/cli/src/commands/config/update.ts
@@ -59,7 +59,10 @@ async function updateCommandAction() {
 		// get the latest version of each plugin
 		const pluginURLsWithLatestVersion = await Promise.all(
 			pluginURLsParsed.map(async (pluginURL) => {
-				const latestVersion = await getLatestVersion(pluginURL.publisher + "/" + pluginURL.name!)
+				const latestVersion = await getLatestVersion(
+					pluginURL.publisher + "/" + pluginURL.name!,
+					pluginURL.name! !== "sdk-js-plugin"
+				)
 				return {
 					...pluginURL,
 					latestVersion,

--- a/source-code/cli/src/utilities/getLatestVersion.ts
+++ b/source-code/cli/src/utilities/getLatestVersion.ts
@@ -1,6 +1,6 @@
 import fetch from "node-fetch"
 
-export async function getLatestVersion(packageName: string): Promise<string | undefined> {
+export async function getLatestVersion(packageName: string, singleDigit = true): Promise<string | undefined> {
 	const response = await fetch(`https://registry.npmjs.org/${packageName}`)
 	const metadata = (await response.json()) as { "dist-tags": { latest: string } }
 	const latestVersion = metadata["dist-tags"]?.latest
@@ -8,7 +8,7 @@ export async function getLatestVersion(packageName: string): Promise<string | un
 	if (latestVersion) {
 		// Extract the major version with a single digit
 		const majorVersion = latestVersion.split(".")[0]
-		return majorVersion
+		return singleDigit ? majorVersion : latestVersion
 	} else {
 		return "latest"
 	}


### PR DESCRIPTION
Pretty self-explanatory, the `npx @inlang/cli config update` command upgrades `sdk-js-plugin` to `"0"` because it only returns the major version.
Now this plugin is excluded from this mechanism and gets the full version returned.

I couldn't test that because I don't have access to multiple dependencies required to run it, but I don't see why it wouldn't work.

Also, I don't know if it's the right branch to PR to, nor if it should be added as a test case in a `.test.ts` file.